### PR TITLE
feat(auth): Add support for a simple API Key verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ It may be used both by mining pools and exchanges.
 
 Copy `config.js.template` to `config.js`, and then fill in the variables. Finally, run `npm start`.
 
+## Authentication
+
+You can enable a simple API Key verification in the `config.js` file. In this case, your requests must include the header `X-API-KEY` with the correct key.
+
+If you are using cURL to test, you can include the header using the `-H` parameter, e.g., `curl -H "X-API-Key: YourKey" http://localhost:8000/0/balance`.
+
+It follows the [Swagger Specification for API Keys](https://swagger.io/docs/specification/authentication/api-keys/).
+
 ## How to use?
 
 Check out the full documentation in the OpenAPI Documentation in `api-docs.js`.

--- a/api-docs.js
+++ b/api-docs.js
@@ -10,6 +10,18 @@ const apiDoc = {
     version: '0.1.0',
   },
   produces: [ "application/json" ],
+  components: {
+    securitySchemes: {
+      ApiKeyAuth: {
+        type: 'apiKey',
+        'in': 'header',
+        name: 'X-API-KEY',
+      },
+    },
+  },
+  security: {
+    ApiKeyAuth: [],
+  },
   paths: {
     '/status': {
       get: {

--- a/api-key-auth.js
+++ b/api-key-auth.js
@@ -1,0 +1,19 @@
+
+function apiKeyAuth(key) {
+  return (req, res, next) => {
+    const userKey = req.headers['x-api-key'];
+    if (!userKey) {
+      res.status(401).json({ auth: false, message: 'Missing X-API-KEY header.' });
+      return;
+    }
+
+    if (userKey !== key) {
+      res.status(401).json({ auth: false, message: 'Wrong api key.' });
+      return;
+    }
+
+    next();
+  };
+}
+
+export default apiKeyAuth;

--- a/config.js.template
+++ b/config.js.template
@@ -3,6 +3,9 @@ module.exports = {
   http_bind_address: 'localhost',
   http_port: 8000,
 
+  // Uncomment the following line to enable API Key Auth.
+  // http_api_key: 'YOUR_PRIVATE_KEY',
+
   // Hathor Full-node
   network: 'mainnet',
   server: 'https://node2.mainnet.hathor.network/v1a/',

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import hathorLib from '@hathor/wallet-lib';
 import config from './config';
 import Wallet from './wallet';
 import apiDocs from './api-docs';
+import apiKeyAuth from './api-key-auth';
 
 const humanState = {
   [Wallet.CLOSED]: 'Closed',
@@ -95,6 +96,9 @@ walletRouter.post('/simple-send-tx', (req, res) => {
   });
 });
 
+if (config.http_api_key) {
+  app.use(apiKeyAuth(config.http_api_key));
+}
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use('/0', walletRouter);


### PR DESCRIPTION
Maybe it closes #3, but we need to discuss it further.

This implementation follows the [Swagger Specification for API Keys](https://swagger.io/docs/specification/authentication/api-keys/).

Before merging:

- [x] Change to branch `dev` after `feat/poc` is merged.