### PR TITLE
feat: send tx now uses tx mining API

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,11 +164,16 @@ walletRouter.post('/simple-send-tx', (req, res) => {
   const wallet = req.wallet;
   const address = req.body.address;
   const value = parseInt(req.body.value);
-  wallet.sendTransaction(address, value).then((response) => {
-    res.send(response);
-  }, (error) => {
-    res.send({success: false, error});
-  });
+  const ret = wallet.sendTransaction(address, value);
+  if (ret.success) {
+    ret.promise.then((response) => {
+      res.send(response);
+    }, (error) => {
+      res.send({success: false, error});
+    });
+  } else {
+    res.send({success: false, error: ret.message});
+  }
 });
 
 walletRouter.post('/stop', (req, res) => {

--- a/index.js
+++ b/index.js
@@ -179,11 +179,16 @@ walletRouter.post('/simple-send-tx', (req, res) => {
 walletRouter.post('/send-tx', (req, res) => {
   const wallet = req.wallet;
   const outputs = req.body.outputs;
-  wallet.sendManyOutputsTransaction(outputs).then((response) => {
-    res.send(response);
-  }, (error) => {
-    res.send({success: false, error});
-  });
+  const ret = wallet.sendManyOutputsTransaction(outputs)
+  if (ret.success) {
+    ret.promise.then((response) => {
+      res.send(response);
+    }, (error) => {
+      res.send({success: false, error});
+    });
+  } else {
+    res.send({success: false, error: ret.message});
+  }
 });
 
 walletRouter.post('/stop', (req, res) => {


### PR DESCRIPTION
Adapting send transaction code to use tx mining API. Wallet headless does not give partial feedback to the user of time estimation. It just waits for the tx to be mined, completed and propagated to the network.