### PR TITLE
fix: add urlencode to curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Parameters:
 `seedKey`: Parameter to define which seed (from the object seeds in the config file) will be used to generate the wallet.
 
 ```bash
-$ curl -X POST --data "wallet-id=id" --data "passphrase=123" --data "seedKey=default" http://localhost:8000/start
+$ curl -X POST --data "wallet-id=id" --data-urlencode "passphrase=123" --data "seedKey=default" http://localhost:8000/start
 {"success":true}
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
User EuroLine was having problems loading his wallet. The one loaded in Desktop wallet was different from the one in wallet headless. It seems the problem was the passphrase, that had special chars.