### PR TITLE
feat: add POST to create token and token as optional parameters on balance and simple-send-tx

### DIFF
--- a/api-docs.js
+++ b/api-docs.js
@@ -153,6 +153,15 @@ const apiDoc = {
               type: 'string',
             },
           },
+          {
+            name: 'token',
+            'in': 'query',
+            description: 'Token uid. Optional parameter to get the balance from a token different than HTR.',
+            required: false,
+            schema: {
+              type: 'string',
+            },
+          },
         ],
         responses: {
           200: {
@@ -205,6 +214,15 @@ const apiDoc = {
               type: 'boolean',
             },
           },
+          {
+            name: 'index',
+            'in': 'query',
+            description: 'Get the address in this specific derivation path index.',
+            required: false,
+            schema: {
+              type: 'integer',
+            },
+          },
         ],
         responses: {
           200: {
@@ -215,6 +233,49 @@ const apiDoc = {
                   success: {
                     summary: 'Success',
                     value: {"address":"H8bt9nYhUNJHg7szF32CWWi1eB8PyYZnbt"}
+                  },
+                  'wallet-not-ready': {
+                    summary: 'Wallet is not ready yet',
+                    value: {"success":false,"message":"Wallet is not ready.","state":1}
+                  },
+                  'no-wallet-id': {
+                    summary: 'No wallet id parameter',
+                    value: {"success":false,"message":"Parameter 'wallet-id' is required."}
+                  },
+                  'invalid-wallet-id': {
+                    summary: 'Wallet id parameter is invalid',
+                    value: {"success":false,"message":"Invalid wallet-id parameter."}
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wallet/addresses': {
+      get: {
+        summary: 'Return all generated addresses of the wallet.',
+        parameters: [
+          {
+            name: 'x-wallet-id',
+            'in': 'header',
+            description: 'Define the key of the corresponding wallet it will be executed the request.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          }
+        ],
+        responses: {
+          200: {
+            description: 'Return the addresses',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {"addresses":["H8bt9nYhUNJHg7szF32CWWi1eB8PyYZnbt", "HPxB4dKccUWbECh1XMWPEgZVZP2EC34BbB"]}
                   },
                   'wallet-not-ready': {
                     summary: 'Wallet is not ready yet',
@@ -326,7 +387,43 @@ const apiDoc = {
                 },
               }
             }
+          },
+          {
+            name: 'inputs',
+            'in': 'formData',
+            description: 'An array of inputs with objects {hash, index}',
+            required: false,
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                hash: {
+                  type: 'string',
+                },
+                index: {
+                  type: 'integer',
+                },
+              }
+            }
 
+          },
+          {
+            name: 'token',
+            'in': 'formData',
+            description: 'Token to send if not HTR.',
+            required: false,
+            type: 'object',
+            properties: {
+              uid: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              symbol: {
+                type: 'string',
+              },
+            }
           },
         ],
         responses: {
@@ -362,6 +459,203 @@ const apiDoc = {
         },
       },
     },
+    '/wallet/create-token': {
+      post: {
+        summary: 'Create a token.',
+        parameters: [
+          {
+            name: 'x-wallet-id',
+            'in': 'header',
+            description: 'Define the key of the corresponding wallet it will be executed the request.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'name',
+            'in': 'formData',
+            description: 'The name of the token.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'symbol',
+            'in': 'formData',
+            description: 'The symbol of the token.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'amount',
+            'in': 'formData',
+            description: 'The amount of tokens to mint. It must be an integer with the value in cents, i.e., 123 means 1.23.',
+            required: true,
+            type: 'integer',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Create the token',
+            content: {
+              'application/json': {
+                examples: {
+                  error: {
+                    summary: 'Insuficient amount of tokens',
+                    value: {"success":false,"error": "Don't have enough HTR funds to mint this amount."}
+                  },
+                  success: {
+                    summary: 'Success',
+                    value: {"hash": "00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","nonce": 200,"timestamp": 1610730485,"version": 2,"weight": 8.000001,"parents": [ "006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d", "001ac1d7ff68e9bf4bf67b81fee517f08b06be564d7a28b13e41fea158b4cf54" ], "inputs": [ { "tx_id": "00efbc1f99dc50a3c7ff7e7193ebfaa3df28eec467bcd0555eaf703ae773ab5c", "index": 1, "data": "RzBFAiEAxFEPpgauWvPzCoM3zknUdOsWL2RwBu8JSOS6yKGufRICIAOf/mKgLka73wiwXUzVLC/kMYXKmqYSnA2oki6pm9qBIQOyMiKwc3u+O4mBUuN7BFLMwW9hmvUL+KmYPr1N0fl8ww==" } ], "outputs": [ { "value": 6290, "token_data": 0, "script": "dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==" }, { "value": 1000, "token_data": 1, "script": "dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==" }, { "value": 1, "token_data": 129, "script": "dqkUL2o1cHLbOQZfj+yVFP0rof9S+WGIrA==" }, { "value": 2, "token_data": 129, "script": "dqkUVawHzE0m6oUvfyzz2cAUdvYlP/SIrA==" } ], "tokens": [], "token_name": "Test", "token_symbol": "TST" }
+                  },
+                  'wallet-not-ready': {
+                    summary: 'Wallet is not ready yet',
+                    value: {"success":false,"message":"Wallet is not ready.","state":1}
+                  },
+                  'no-wallet-id': {
+                    summary: 'No wallet id parameter',
+                    value: {"success":false,"message":"Parameter 'wallet-id' is required."}
+                  },
+                  'invalid-wallet-id': {
+                    summary: 'Wallet id parameter is invalid',
+                    value: {"success":false,"message":"Invalid wallet-id parameter."}
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wallet/mint-tokens': {
+      post: {
+        summary: 'Mint tokens.',
+        parameters: [
+          {
+            name: 'x-wallet-id',
+            'in': 'header',
+            description: 'Define the key of the corresponding wallet it will be executed the request.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'token',
+            'in': 'formData',
+            description: 'The uid of the token to mint.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'amount',
+            'in': 'formData',
+            description: 'The amount of tokens to mint. It must be an integer with the value in cents, i.e., 123 means 1.23.',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'address',
+            'in': 'formData',
+            description: 'Destination address of the minted tokens.',
+            required: false,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Mint tokens.',
+            content: {
+              'application/json': {
+                examples: {
+                  error: {
+                    summary: 'Insuficient amount of tokens',
+                    value: {"success":false,"error": "Don't have enough HTR funds to mint this amount."}
+                  },
+                  success: {
+                    summary: 'Success',
+                    value: {"hash":"0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","nonce":2,"timestamp":1610730780,"version":1,"weight":8.000001,"parents":["00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d"],"inputs":[{"tx_id":"00c6fe8179e6f93d220707a58b94fa876d81eb0d7caaa713e865ba4a5b24a03e","index":0,"data":"RjBEAiBsR2Yv7g9juMwLjgt+XUbuRGRb9BLyHQVQZSPX4pFToQIgES1EO8QHewCiPTg5T228++eZk8CdzkJ3itvxsVuAcV0hA7IyIrBze747iYFS43sEUszBb2Ga9Qv4qZg+vU3R+XzD"},{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":2,"data":"RjBEAiAD3Iq6Uy5y+phl9j6Q2wU+zEqWHXt4YgTvBXkQrBZYAQIgKBXSf8pDZwA6Trl+OVtRRoTNFTbQYK6300aZ0IPNuJEhA9jOwwMvZUEgKSQnarS0hLYt2px6eas4E03c4pJpRGfH"}],"outputs":[{"value":90,"token_data":0,"script":"dqkUeAmBO6S3tT7y/HyCXrqOWXkOETWIrA=="},{"value":1000,"token_data":1,"script":"dqkUeAmBO6S3tT7y/HyCXrqOWXkOETWIrA=="},{"value":1,"token_data":129,"script":"dqkUPqMYv+My2kCjdYqx6nHNxLVtRpSIrA=="}],"tokens":["00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"]}
+                  },
+                  'wallet-not-ready': {
+                    summary: 'Wallet is not ready yet',
+                    value: {"success":false,"message":"Wallet is not ready.","state":1}
+                  },
+                  'no-wallet-id': {
+                    summary: 'No wallet id parameter',
+                    value: {"success":false,"message":"Parameter 'wallet-id' is required."}
+                  },
+                  'invalid-wallet-id': {
+                    summary: 'Wallet id parameter is invalid',
+                    value: {"success":false,"message":"Invalid wallet-id parameter."}
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wallet/melt-tokens': {
+      post: {
+        summary: 'Melt tokens.',
+        parameters: [
+          {
+            name: 'x-wallet-id',
+            'in': 'header',
+            description: 'Define the key of the corresponding wallet it will be executed the request.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'token',
+            'in': 'formData',
+            description: 'The uid of the token to melt.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'amount',
+            'in': 'formData',
+            description: 'The amount of tokens to melt. It must be an integer with the value in cents, i.e., 123 means 1.23.',
+            required: true,
+            type: 'integer',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Melt tokens.',
+            content: {
+              'application/json': {
+                examples: {
+                  error: {
+                    summary: 'Insuficient amount of tokens',
+                    value: {"success":false,"error": "There aren't enough inputs to melt."}
+                  },
+                  success: {
+                    summary: 'Success',
+                    value: {{"hash":"00a963872c86978873cce570bbcfc2c40bb8714d5970f80cdc5477c693b01cbf","nonce":256,"timestamp":1610730988,"version":1,"weight":8.000001,"parents":["0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"],"inputs":[{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":3,"data":"RjBEAiAQE9pqOo/xlWhv/4gLW6eP5C8s+O/ut4u6Yofg1sbYhQIgQR5KhNrx6SPRij7CbT0dXE3/n3nq9ES13fSZAIBw3+MhAhjIOGT0cwytQmoDCpauM7r3xox0xgzSpfy7MHfYR1Qp"},{"tx_id":"0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","index":1,"data":"RjBEAiByaprtd/MjMpwPy3O0xr8LjLdPzVjOV0G54NM/zZ5HsAIgRRFmwxTR1hFg2HOgsYKEA2/BvaUyaPTEEmX7oxCWxMMhA+U12voabjO6b2tdHJvxNs4lYd2vvV7RBmSQiSLqcPhH"},{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":1,"data":"RjBEAiBU+XD4Bgm6VHd8H//61aYXDvr7gyZFE2otlbQs+FVpAwIgbZvxSvPUu0EC7aKblP0qsglbsWVzW0KAMIk35acmsKIhA4RC86eRBr2xSH487ramK1DWBOB2ffSeuxVDDnoZPwPp"}],"outputs":[{"value":2,"token_data":129,"script":"dqkUFj/MJhGG+ZGCwDF3BlyeeoP2DymIrA=="},{"value":20,"token_data":0,"script":"dqkUBxW0lxHapoovTTGBVdEo4iNl+gWIrA=="}],"tokens":["00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"]}}
+                  },
+                  'wallet-not-ready': {
+                    summary: 'Wallet is not ready yet',
+                    value: {"success":false,"message":"Wallet is not ready.","state":1}
+                  },
+                  'no-wallet-id': {
+                    summary: 'No wallet id parameter',
+                    value: {"success":false,"message":"Parameter 'wallet-id' is required."}
+                  },
+                  'invalid-wallet-id': {
+                    summary: 'Wallet id parameter is invalid',
+                    value: {"success":false,"message":"Invalid wallet-id parameter."}
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     '/wallet/tx-history': {
       get: {
         summary: 'Return the transaction history',
@@ -373,6 +667,15 @@ const apiDoc = {
             required: true,
             schema: {
               type: 'string',
+            },
+          },
+          {
+            name: 'limit',
+            'in': 'query',
+            description: 'Sort and return only the quantity in limit.',
+            required: false,
+            schema: {
+              type: 'integer',
             },
           },
         ],

--- a/api-docs.js
+++ b/api-docs.js
@@ -7,7 +7,7 @@ const apiDoc = {
   info: {
     title: 'Headless Hathor Wallet API',
     description: 'This wallet is fully controlled through an HTTP API.',
-    version: '0.1.0',
+    version: '0.5.6',
   },
   produces: [ "application/json" ],
   components: {
@@ -635,7 +635,7 @@ const apiDoc = {
                   },
                   success: {
                     summary: 'Success',
-                    value: {{"hash":"00a963872c86978873cce570bbcfc2c40bb8714d5970f80cdc5477c693b01cbf","nonce":256,"timestamp":1610730988,"version":1,"weight":8.000001,"parents":["0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"],"inputs":[{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":3,"data":"RjBEAiAQE9pqOo/xlWhv/4gLW6eP5C8s+O/ut4u6Yofg1sbYhQIgQR5KhNrx6SPRij7CbT0dXE3/n3nq9ES13fSZAIBw3+MhAhjIOGT0cwytQmoDCpauM7r3xox0xgzSpfy7MHfYR1Qp"},{"tx_id":"0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","index":1,"data":"RjBEAiByaprtd/MjMpwPy3O0xr8LjLdPzVjOV0G54NM/zZ5HsAIgRRFmwxTR1hFg2HOgsYKEA2/BvaUyaPTEEmX7oxCWxMMhA+U12voabjO6b2tdHJvxNs4lYd2vvV7RBmSQiSLqcPhH"},{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":1,"data":"RjBEAiBU+XD4Bgm6VHd8H//61aYXDvr7gyZFE2otlbQs+FVpAwIgbZvxSvPUu0EC7aKblP0qsglbsWVzW0KAMIk35acmsKIhA4RC86eRBr2xSH487ramK1DWBOB2ffSeuxVDDnoZPwPp"}],"outputs":[{"value":2,"token_data":129,"script":"dqkUFj/MJhGG+ZGCwDF3BlyeeoP2DymIrA=="},{"value":20,"token_data":0,"script":"dqkUBxW0lxHapoovTTGBVdEo4iNl+gWIrA=="}],"tokens":["00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"]}}
+                    value: {"hash":"00a963872c86978873cce570bbcfc2c40bb8714d5970f80cdc5477c693b01cbf","nonce":256,"timestamp":1610730988,"version":1,"weight":8.000001,"parents":["0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"],"inputs":[{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":3,"data":"RjBEAiAQE9pqOo/xlWhv/4gLW6eP5C8s+O/ut4u6Yofg1sbYhQIgQR5KhNrx6SPRij7CbT0dXE3/n3nq9ES13fSZAIBw3+MhAhjIOGT0cwytQmoDCpauM7r3xox0xgzSpfy7MHfYR1Qp"},{"tx_id":"0072abb9f3f98aa9d9a4e46d6c4f07c16258dbc963f89213f9f4d03dff5977bc","index":1,"data":"RjBEAiByaprtd/MjMpwPy3O0xr8LjLdPzVjOV0G54NM/zZ5HsAIgRRFmwxTR1hFg2HOgsYKEA2/BvaUyaPTEEmX7oxCWxMMhA+U12voabjO6b2tdHJvxNs4lYd2vvV7RBmSQiSLqcPhH"},{"tx_id":"00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277","index":1,"data":"RjBEAiBU+XD4Bgm6VHd8H//61aYXDvr7gyZFE2otlbQs+FVpAwIgbZvxSvPUu0EC7aKblP0qsglbsWVzW0KAMIk35acmsKIhA4RC86eRBr2xSH487ramK1DWBOB2ffSeuxVDDnoZPwPp"}],"outputs":[{"value":2,"token_data":129,"script":"dqkUFj/MJhGG+ZGCwDF3BlyeeoP2DymIrA=="},{"value":20,"token_data":0,"script":"dqkUBxW0lxHapoovTTGBVdEo4iNl+gWIrA=="}],"tokens":["00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277"]}
                   },
                   'wallet-not-ready': {
                     summary: 'Wallet is not ready yet',

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ app.post('/start', (req, res) => {
     // We already have a wallet for this key
     // so we log that it won't start a new one because
     // it must first stop the old wallet and then start the new
-    console.log('Error starting wallet because this wallet-id is already used. You must stop the wallet using it first.');
+    console.log('Error starting wallet because this wallet-id is already in use. You must stop the wallet first.');
     res.send({
       success: false,
       message: `Failed to start wallet with wallet id ${walletID}`,
@@ -219,6 +219,7 @@ walletRouter.post('/simple-send-tx', (req, res) => {
 walletRouter.post('/send-tx', (req, res) => {
   const wallet = req.wallet;
   const outputs = req.body.outputs;
+  // Expects array of objects with {'hash', 'index'}
   const inputs = req.body.inputs || [];
   // Expects object with {'uid', 'name', 'symbol'}
   const token = req.body.token || null;

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ app.get('/docs', (req, res) => {
   res.send(apiDocs);
 });
 
+/**
+ * POST request to start a new wallet
+ * For the docs, see api-docs.js
+ */
 app.post('/start', (req, res) => {
   // We expect the user to send the seed he wants to use
   if (!('seedKey' in req.body)) {
@@ -145,6 +149,10 @@ walletRouter.use((req, res, next) => {
   next();
 });
 
+/**
+ * GET request to get the status of a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.get('/status', (req, res) => {
   const wallet = req.wallet;
   res.send({
@@ -156,6 +164,10 @@ walletRouter.get('/status', (req, res) => {
   });
 });
 
+/**
+ * GET request to get the balance of a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.get('/balance', (req, res) => {
   const wallet = req.wallet;
   // Expects token uid
@@ -164,6 +176,10 @@ walletRouter.get('/balance', (req, res) => {
   res.send(balance);
 });
 
+/**
+ * GET request to get an address of a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.get('/address', (req, res) => {
   const wallet = req.wallet;
   const index = req.query.index || null;
@@ -177,6 +193,10 @@ walletRouter.get('/address', (req, res) => {
   res.send({ address });
 });
 
+/**
+ * GET request to get all addresses of a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.get('/addresses', (req, res) => {
   const wallet = req.wallet;
   // TODO Add pagination
@@ -184,6 +204,10 @@ walletRouter.get('/addresses', (req, res) => {
   res.send({ addresses });
 });
 
+/**
+ * GET request to get the transaction history of a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.get('/tx-history', (req, res) => {
   // TODO Add pagination
   const wallet = req.wallet;
@@ -198,6 +222,10 @@ walletRouter.get('/tx-history', (req, res) => {
   }
 });
 
+/**
+ * POST request to send a transaction with only one output
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/simple-send-tx', (req, res) => {
   const wallet = req.wallet;
   const address = req.body.address;
@@ -216,6 +244,10 @@ walletRouter.post('/simple-send-tx', (req, res) => {
   }
 });
 
+/**
+ * POST request to send a transaction with many outputs and inputs selection
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/send-tx', (req, res) => {
   const wallet = req.wallet;
   const outputs = req.body.outputs;
@@ -223,7 +255,7 @@ walletRouter.post('/send-tx', (req, res) => {
   const inputs = req.body.inputs || [];
   // Expects object with {'uid', 'name', 'symbol'}
   const token = req.body.token || null;
-  const ret = wallet.sendManyOutputsTransaction(outputs, token, inputs)
+  const ret = wallet.sendManyOutputsTransaction(outputs, inputs, token)
   if (ret.success) {
     ret.promise.then((response) => {
       res.send(response);
@@ -235,6 +267,10 @@ walletRouter.post('/send-tx', (req, res) => {
   }
 });
 
+/**
+ * POST request to create a token
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/create-token', (req, res) => {
   const wallet = req.wallet;
   const name = req.body.name;
@@ -253,6 +289,10 @@ walletRouter.post('/create-token', (req, res) => {
   }
 });
 
+/**
+ * POST request to mint tokens
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/mint-tokens', (req, res) => {
   const wallet = req.wallet;
   const token = req.body.token;
@@ -270,6 +310,10 @@ walletRouter.post('/mint-tokens', (req, res) => {
   }
 });
 
+/**
+ * POST request to melt tokens
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/melt-tokens', (req, res) => {
   const wallet = req.wallet;
   const token = req.body.token;
@@ -286,6 +330,10 @@ walletRouter.post('/melt-tokens', (req, res) => {
   }
 });
 
+/**
+ * POST request to stop a wallet
+ * For the docs, see api-docs.js
+ */
 walletRouter.post('/stop', (req, res) => {
   // Stop wallet and remove from wallets object
   const wallet = req.wallet;

--- a/index.js
+++ b/index.js
@@ -84,11 +84,14 @@ app.post('/start', (req, res) => {
 
   if (walletID in wallets) {
     // We already have a wallet for this key
-    // so we stop the old wallet and start the new one
-    const oldWallet = wallets[walletID];
-    oldWallet.stop();
-
-    delete wallets[walletID];
+    // so we log that it won't start a new one because
+    // it must first stop the old wallet and then start the new
+    console.log('Error starting wallet because this wallet-id is already used. You must stop the wallet using it first.');
+    res.send({
+      success: false,
+      message: `Failed to start wallet with wallet id ${walletID}`,
+    });
+    return;
   }
 
   const wallet = new HathorWallet(walletConfig);

--- a/index.js
+++ b/index.js
@@ -197,10 +197,46 @@ walletRouter.post('/create-token', (req, res) => {
   const wallet = req.wallet;
   const name = req.body.name;
   const symbol = req.body.symbol;
-  const amount = req.body.amount;
+  const amount = parseInt(req.body.amount);
   const address = wallet.getCurrentAddress();
-  // XXX HathorWallet class should have a method to createToken, so we don't need to use the pin hardcoded and handle sendTransaction
-  const ret = tokens.createToken(address, name, symbol, amount, '123')
+  const ret = wallet.createNewToken(name, symbol, amount, address);
+  if (ret.success) {
+    const sendTransaction = ret.sendTransaction;
+    sendTransaction.start();
+    sendTransaction.promise.then((response) => {
+      res.send(response);
+    }, (error) => {
+      res.send({success: false, error});
+    });
+  } else {
+    res.send({success: false, error: ret.message});
+  }
+});
+
+walletRouter.post('/mint-tokens', (req, res) => {
+  const wallet = req.wallet;
+  const token = req.body.token;
+  const amount = parseInt(req.body.amount);
+  const address = req.body.address || null;
+  const ret = wallet.mintTokens(token, amount, address);
+  if (ret.success) {
+    const sendTransaction = ret.sendTransaction;
+    sendTransaction.start();
+    sendTransaction.promise.then((response) => {
+      res.send(response);
+    }, (error) => {
+      res.send({success: false, error});
+    });
+  } else {
+    res.send({success: false, error: ret.message});
+  }
+});
+
+walletRouter.post('/melt-tokens', (req, res) => {
+  const wallet = req.wallet;
+  const token = req.body.token;
+  const amount = parseInt(req.body.amount);
+  const ret = wallet.meltTokens(token, amount);
   if (ret.success) {
     const sendTransaction = ret.sendTransaction;
     sendTransaction.start();

--- a/index.js
+++ b/index.js
@@ -155,6 +155,7 @@ walletRouter.get('/status', (req, res) => {
 
 walletRouter.get('/balance', (req, res) => {
   const wallet = req.wallet;
+  // Expects token uid
   const token = req.query.token || null;
   const balance = wallet.getBalance(token);
   res.send(balance);
@@ -177,6 +178,7 @@ walletRouter.post('/simple-send-tx', (req, res) => {
   const wallet = req.wallet;
   const address = req.body.address;
   const value = parseInt(req.body.value);
+  // Expects object with {'uid', 'name', 'symbol'}
   const token = req.body.token || null;
   const ret = wallet.sendTransaction(address, value, token);
   if (ret.success) {
@@ -193,7 +195,9 @@ walletRouter.post('/simple-send-tx', (req, res) => {
 walletRouter.post('/send-tx', (req, res) => {
   const wallet = req.wallet;
   const outputs = req.body.outputs;
-  const ret = wallet.sendManyOutputsTransaction(outputs)
+  // Expects object with {'uid', 'name', 'symbol'}
+  const token = req.body.token || null;
+  const ret = wallet.sendManyOutputsTransaction(outputs, token)
   if (ret.success) {
     ret.promise.then((response) => {
       res.send(response);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -871,9 +871,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.16.9.tgz",
-      "integrity": "sha512-kNpFZE1zU+FkO+ZKeB+hnz7ZX+oahSjPJI82xJV3fg2ZPkEZ29fR9F+iWZiu4e3ieKCULr3hFDr2u6OvO8eQOg==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.16.10.tgz",
+      "integrity": "sha512-7QqS9RspYVVv6+/6ZJ8aeZMIv/pavuOnDoffGC0+WN55fHI5WduwKRnPR3LfW84LgfpO8qkWnzNPuqD69ces6Q==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-mnemonic": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Hathor Wallet Headless, i.e., without graphical user interface",
   "main": "index.js",
   "dependencies": {
@@ -8,7 +8,7 @@
     "@babel/core": "^7.8.4",
     "@babel/node": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
-    "@hathor/wallet-lib": "^0.16.9",
+    "@hathor/wallet-lib": "^0.16.10",
     "express": "^4.17.1"
   },
   "scripts": {


### PR DESCRIPTION
There are some features/fixes on this PR:

1. If I receive a `/start` to a key I already have, I stop the old wallet and start a new one. This fixes a bug when sending `/start` many times to the same key/wallet
2. Add optional token parameter  to `/balance`, `/simple-send/tx` and `/send-tx` endpoints
3. Add endpoint to create, mint and melt tokens (`/create-token`, `/mint-tokens`, `/melt-tokens`)