### PR TITLE
fix: fix address generation for index 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,9 +216,10 @@ walletRouter.get('/address',
     return res.status(400).json(validationResult);
   }
   const wallet = req.wallet;
-  const index = req.query.index || null;
+  const index = req.query.index;
   let address;
-  if (index !== null) {
+  if (index !== undefined) {
+    // Because of isInt and toInt, it's safe to assume that index is now an integer >= 0
     address = wallet.getAddressAtIndex(index);
   } else {
     const markAsUsed = req.query.mark_as_used || false;


### PR DESCRIPTION
We used to get `req.query.index` as string, thus when comparing `const index = req.query.index || null`, when `index = '0'` it used to work fine. However, we've added a sanitization and `toInt` protection. After that, `req.query.index` is already an integer and if `index = 0` the comparison does not work.