### PR TITLE
fix: Allow setting TxMiningUrl using env vars in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.git/

--- a/config.js.docker
+++ b/config.js.docker
@@ -55,6 +55,8 @@ const config = {
   network: getParam('network', 'mainnet'),
   server: getParam('server', 'https://node1.mainnet.hathor.network/v1a/'),
 
+  txMiningUrl: getParam('tx_mining_url', 'https://txmining.mainnet.hathor.network'),
+
   http_api_key: getParam('api_key'),
   httpLogFormat: getParam('http_log_format'),
 


### PR DESCRIPTION
### Acceptance Criteria
- It should be possible to set the txMiningUrl by setting the env var `HEADLESS_TX_MINING_URL` in the Docker container


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
