### PR TITLE
Chore/update browserlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2468,7 +2468,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
       "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
       "requires": {
-        "caniuse-lite": "1.0.30001192",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "1.2.2",
         "electron-to-chromium": "1.3.674",
         "escalade": "3.1.1",
@@ -2577,9 +2577,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001192",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz",
-      "integrity": "sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw=="
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
### Motivation
Every time we run some npm command in the project, we are getting this warning:
```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

I don't even know if that makes any difference here, since this project is not targeted at browsers. I think we have browserlist just because it's a dependency of some babel lib.

But it was annoying and confusing some people.

### Acceptance Criteria
- We should stop receiving this warning when running npm commands in the project


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
