### PR TITLE
chore: change txMiningUrl to null in the config template

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -12,7 +12,8 @@ module.exports = {
 
   // Tx Mining Service
   // This is optional. If you do not set, the hathor-wallet-lib's default will be used.
-  txMiningUrl: 'https://txmining.mainnet.hathor.network/',
+  // Use it only if you want to use your own tx mining service, e.g. 'https://mytxmining.domain/'
+  txMiningUrl: null,
 
   // Wallet seeds
   seeds: {


### PR DESCRIPTION
### Motivation

The instinct of someone who is starting to use the wallet headless is just to copy the config template and edit some parameters. We already had a problem with a user that just copied and changed the network to `testnet` but the txMiningUrl was fixed as the mainnet url. Given that the lib adapt to the wallet network, so I guess the default could be `null` to prevent those problems.

### Acceptance Criteria
- Config template file should have `txMiningUrl` config as `null`


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
