### PR TITLE
Integration tests: simple send-tx, send-tx, create-tokens, mint and melt tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ config.js
 node_modules/
 
 coverage
+coverage-integration
 
 .DS_Store

--- a/__tests__/integration/address-info.test.js
+++ b/__tests__/integration/address-info.test.js
@@ -31,6 +31,8 @@ describe('address-info routes', () => {
       });
       customTokenHash = customToken.hash;
 
+      await TestUtils.pauseForWsUpdate();
+
       /*
        * The state here should be:
        * wallet1[1] with some value between 100 and 200 HTR

--- a/__tests__/integration/address-info.test.js
+++ b/__tests__/integration/address-info.test.js
@@ -16,12 +16,11 @@ describe('address-info routes', () => {
     try {
       // A random HTR value for the first wallet
       wallet1 = new WalletHelper('addinfo-1');
-      await wallet1.start();
-      await wallet1.injectFunds(address1balance, 1);
-
       // A fixed custom token amount for the second wallet
       wallet2 = new WalletHelper('addinfo-2');
-      await wallet2.start();
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
+      await wallet1.injectFunds(address1balance, 1);
       await wallet2.injectFunds(10);
       const customToken = await wallet2.createToken({
         amount: 500,

--- a/__tests__/integration/balance.test.js
+++ b/__tests__/integration/balance.test.js
@@ -20,6 +20,8 @@ describe('balance routes', () => {
       await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2, wallet3]);
       await wallet2.injectFunds(wallet2Balance);
       await wallet3.injectFunds(100);
+
+      await TestUtils.pauseForWsUpdate();
     } catch (err) {
       TestUtils.logError(err.stack);
     }
@@ -86,6 +88,8 @@ describe('balance routes', () => {
       amount: tokenAmount,
     });
     const tokenHash = newToken.hash;
+
+    await TestUtils.pauseForWsUpdate();
 
     const balanceResult = await TestUtils.request
       .get('/wallet/balance')

--- a/__tests__/integration/balance.test.js
+++ b/__tests__/integration/balance.test.js
@@ -12,16 +12,13 @@ describe('balance routes', () => {
     try {
       // First wallet, no balance
       wallet1 = new WalletHelper('balance1');
-      await wallet1.start();
-
       // Second wallet, random balance
       wallet2 = new WalletHelper('balance2');
-      await wallet2.start();
-      await wallet2.injectFunds(wallet2Balance);
-
       // Third wallet, balance to be used for custom tokens
       wallet3 = new WalletHelper('custom3');
-      await wallet3.start();
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2, wallet3]);
+      await wallet2.injectFunds(wallet2Balance);
       await wallet3.injectFunds(100);
     } catch (err) {
       TestUtils.logError(err.stack);

--- a/__tests__/integration/configuration/config.js.template
+++ b/__tests__/integration/configuration/config.js.template
@@ -46,14 +46,6 @@ module.exports = {
   },
   */
 
-  // Integration test configs
-  integrationTest: {
-    logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
-    consoleLevel: 'silly',
-    wsUpdateDelay: 1000,
-    walletStartTimeout: 60000,
-  },
-
   // Optional config so you can set the token you want to use in this wallet
   // If this parameter is set you don't need to pass your token when getting balance or sending tokens
   tokenUid: '',

--- a/__tests__/integration/configuration/config.js.template
+++ b/__tests__/integration/configuration/config.js.template
@@ -51,6 +51,7 @@ module.exports = {
     logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
     consoleLevel: 'silly',
     wsUpdateDelay: 1000,
+    walletStartTimeout: 60000,
   },
 
   // Optional config so you can set the token you want to use in this wallet

--- a/__tests__/integration/configuration/config.js.template
+++ b/__tests__/integration/configuration/config.js.template
@@ -46,9 +46,11 @@ module.exports = {
   },
   */
 
-  // Integration test transaction logging
-  integrationTestLog: {
-    outputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
+  // Integration test configs
+  integrationTest: {
+    logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
+    consoleLevel: 'silly',
+    wsUpdateDelay: 1000,
   },
 
   // Optional config so you can set the token you want to use in this wallet

--- a/__tests__/integration/configuration/test.config.js
+++ b/__tests__/integration/configuration/test.config.js
@@ -1,0 +1,18 @@
+/*
+ * This file contains the configurations specific for the integration tests on the Wallet Headless.
+ * Those values are also editable via envrionment variables
+ */
+
+module.exports = {
+  // On CI, should match .github/workflows/integration-test.yml -> upload-artifact
+  logOutputFolder: process.env.TEST_LOG_OUTPUT_FOLDER || 'tmp/',
+
+  // Console level used on winston
+  consoleLevel: process.env.TEST_CONSOLE_LEVEL || 'silly',
+
+  // Defines how long tests should wait before consulting balances after transactions
+  wsUpdateDelay: process.env.TEST_WS_UPDATE_DELAY || 1000,
+
+  // Defines for how long the startMultipleWalletsForTest can run
+  walletStartTimeout: process.env.TEST_WALLET_START_TIMEOUT || 60000,
+};

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -57,10 +57,8 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -73,10 +71,8 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -92,12 +88,9 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -111,14 +104,10 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.error)
-      .toContain('Invalid token name');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.error).toContain('Invalid token name');
     done();
   });
 
@@ -132,10 +121,8 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(true);
-    expect(response.body.hash)
-      .toBeDefined();
+    expect(response.body.success).toBe(true);
+    expect(response.body.hash).toBeDefined();
     done();
   });
 
@@ -152,12 +139,10 @@ describe('create token', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     const transaction = response.body;
-    expect(transaction.success)
-      .toBe(true);
+    expect(transaction.success).toBe(true);
 
     const addr8 = await wallet1.getAddressInfo(9, transaction.hash);
-    expect(addr8.total_amount_received)
-      .toBe(amountTokens);
+    expect(addr8.total_amount_received).toBe(amountTokens);
     done();
   });
 
@@ -173,8 +158,7 @@ describe('create token', () => {
       .set({ 'x-wallet-id': wallet2.walletId });
 
     const transaction = response.body;
-    expect(transaction.success)
-      .toBe(true);
+    expect(transaction.success).toBe(true);
     const customTokenOutputIndex = TestUtils.getOutputIndexFromTx(transaction, 100);
 
     // If the custom token output is 0, the HTR will be on the output index 1. And vice-versa.
@@ -182,8 +166,7 @@ describe('create token', () => {
     const htrChange = transaction.outputs[htrOutputIndex].value;
 
     const addr8 = await wallet1.getAddressInfo(5);
-    expect(addr8.total_amount_received)
-      .toBe(htrChange);
+    expect(addr8.total_amount_received).toBe(htrChange);
     done();
   });
 });

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -219,7 +219,7 @@ describe('create token', () => {
     expect(transaction.success).toBe(true);
 
     // The only output with token_data equals zero is the one containing the HTR change
-    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0)
+    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0);
     const htrChange = transaction.outputs[htrOutputIndex].value;
 
     await TestUtils.pauseForWsUpdate();
@@ -245,14 +245,14 @@ describe('create token', () => {
     expect(transaction.success).toBe(true);
 
     // The only output with token_data equals zero is the one containing the HTR change
-    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0)
+    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0);
     const htrChange = transaction.outputs[htrOutputIndex].value;
 
     await TestUtils.pauseForWsUpdate();
 
     const addr4 = await wallet2.getAddressInfo(4);
     expect(addr4.total_amount_received).toBe(htrChange);
-    const addr4C = await wallet2.getAddressInfo(4, transaction.hash)
+    const addr4C = await wallet2.getAddressInfo(4, transaction.hash);
     expect(addr4C.total_amount_available).toBe(200);
     done();
   });

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -5,15 +5,6 @@ describe('create token', () => {
   let wallet1;
   let wallet2;
 
-  const fundTx1 = {
-    hash: null,
-    index: null
-  };
-  const fundTx2 = {
-    hash: null,
-    index: null
-  };
-
   const tokenA = {
     name: 'Token A',
     symbol: 'TKA',
@@ -30,14 +21,8 @@ describe('create token', () => {
     wallet2 = new WalletHelper('create-token-2');
 
     await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
-    const fundTxObj1 = await wallet1.injectFunds(10, 0);
-    fundTx1.hash = fundTxObj1.hash;
-    fundTx1.index = TestUtils.getOutputIndexFromTx(fundTxObj1, 10);
-
-    const fundTxObj2 = await wallet1.injectFunds(10, 1);
-    fundTx2.hash = fundTxObj2.hash;
-    fundTx2.index = TestUtils.getOutputIndexFromTx(fundTxObj2, 10);
-
+    await wallet1.injectFunds(10, 0);
+    await wallet1.injectFunds(10, 1);
     await wallet2.injectFunds(10, 0);
   });
 
@@ -160,10 +145,9 @@ describe('create token', () => {
 
     const transaction = response.body;
     expect(transaction.success).toBe(true);
-    const customTokenOutputIndex = TestUtils.getOutputIndexFromTx(transaction, 100);
 
-    // If the custom token output is 0, the HTR will be on the output index 1. And vice-versa.
-    const htrOutputIndex = customTokenOutputIndex === 1 ? 0 : 1;
+    // The only output with token_data equals zero is the one containing the HTR change
+    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0)
     const htrChange = transaction.outputs[htrOutputIndex].value;
 
     await TestUtils.pauseForWsUpdate();

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -191,8 +191,10 @@ describe('create token', () => {
 
     await TestUtils.pauseForWsUpdate();
 
+    const htrBalance = await wallet1.getBalance();
     const tkaBalance = await wallet1.getBalance(response.body.hash);
-    expect(tkaBalance.available).toBe(100);
+    expect(htrBalance.available).toBe(19); // The initial 20 minus 1
+    expect(tkaBalance.available).toBe(100); // The newly minted TKA tokens
     done();
   });
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -56,13 +56,13 @@ describe('create token', () => {
     done();
   });
 
-  it('should reject a name with more than 30 characters', async done => {
+  it.skip('should reject a name with more than 30 characters', async done => {
     const response = await TestUtils.request
       .post('/wallet/create-token')
       .send({
         name: 'Name input with more than 30 characters',
         symbol: tokenA.symbol,
-        amount: 1000
+        amount: 2000
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -78,7 +78,7 @@ describe('create token', () => {
       .send({
         name: tokenA.name,
         symbol: 'TKABCD',
-        amount: 1000
+        amount: 2000
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -141,9 +141,9 @@ describe('create token', () => {
     done();
   });
 
-  // Insuficcient funds
+  // insufficient funds
 
-  it('should reject for insuficcient funds', async done => {
+  it('should reject for insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/create-token')
       .send({

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -30,16 +30,15 @@ describe('create token', () => {
     wallet2 = new WalletHelper('create-token-2');
 
     await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
-    const fundTxObj1 = await wallet1.injectFunds(10, 0, { doNotWait: true });
+    const fundTxObj1 = await wallet1.injectFunds(10, 0);
     fundTx1.hash = fundTxObj1.hash;
     fundTx1.index = TestUtils.getOutputIndexFromTx(fundTxObj1, 10);
 
-    const fundTxObj2 = await wallet1.injectFunds(10, 1, { doNotWait: true });
+    const fundTxObj2 = await wallet1.injectFunds(10, 1);
     fundTx2.hash = fundTxObj2.hash;
     fundTx2.index = TestUtils.getOutputIndexFromTx(fundTxObj2, 10);
 
-    await wallet2.injectFunds(10, 0, { doNotWait: true });
-    await TestUtils.delay(1000);
+    await wallet2.injectFunds(10, 0);
   });
 
   afterAll(async () => {
@@ -141,6 +140,8 @@ describe('create token', () => {
     const transaction = response.body;
     expect(transaction.success).toBe(true);
 
+    await TestUtils.pauseForWsUpdate();
+
     const addr8 = await wallet1.getAddressInfo(9, transaction.hash);
     expect(addr8.total_amount_received).toBe(amountTokens);
     done();
@@ -164,6 +165,8 @@ describe('create token', () => {
     // If the custom token output is 0, the HTR will be on the output index 1. And vice-versa.
     const htrOutputIndex = customTokenOutputIndex === 1 ? 0 : 1;
     const htrChange = transaction.outputs[htrOutputIndex].value;
+
+    await TestUtils.pauseForWsUpdate();
 
     const addr8 = await wallet1.getAddressInfo(5);
     expect(addr8.total_amount_received).toBe(htrChange);

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -122,23 +122,6 @@ describe('create token', () => {
     done();
   });
 
-  // The application is incorrectly allowing to create a token for an outside address.
-  it.skip('should reject creating token for address not in the wallet', async done => {
-    const response = await TestUtils.request
-      .post('/wallet/create-token')
-      .send({
-        name: tokenA.name,
-        symbol: tokenA.symbol,
-        amount: 500,
-        address: WALLET_CONSTANTS.genesis.addresses[3]
-      })
-      .set({ 'x-wallet-id': wallet1.walletId });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(false);
-    done();
-  });
-
   // The application is incorrectly allowing external addresses to receive the change
   it.skip('should reject creating token for change address not in the wallet', async done => {
     const response = await TestUtils.request

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,0 +1,189 @@
+import { getRandomInt, TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('create token', () => {
+  let wallet1;
+  let wallet2;
+
+  const fundTx1 = {
+    hash: null,
+    index: null
+  };
+  const fundTx2 = {
+    hash: null,
+    index: null
+  };
+
+  const tokenA = {
+    name: 'Token A',
+    symbol: 'TKA',
+    uid: null
+  };
+  const tokenB = {
+    name: 'Token B',
+    symbol: 'TKB',
+    uid: null
+  };
+
+  beforeAll(async () => {
+    wallet1 = new WalletHelper('create-token-1');
+    wallet2 = new WalletHelper('create-token-2');
+
+    await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
+    const fundTxObj1 = await wallet1.injectFunds(10, 0, { doNotWait: true });
+    fundTx1.hash = fundTxObj1.hash;
+    fundTx1.index = TestUtils.getOutputIndexFromTx(fundTxObj1, 10);
+
+    const fundTxObj2 = await wallet1.injectFunds(10, 1, { doNotWait: true });
+    fundTx2.hash = fundTxObj2.hash;
+    fundTx2.index = TestUtils.getOutputIndexFromTx(fundTxObj2, 10);
+
+    await wallet2.injectFunds(10, 0, { doNotWait: true });
+    await TestUtils.delay(1000);
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+  });
+
+  // Testing failures first, that do not cause side-effects on the blockchain
+
+  it('should reject missing name parameter', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        symbol: tokenA.symbol,
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.success)
+      .toBe(false);
+    done();
+  });
+
+  it('should reject missing symbol parameter', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenA.name,
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.success)
+      .toBe(false);
+    done();
+  });
+
+  // Insuficcient funds
+
+  it('should reject for insuficcient funds', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenA.name,
+        symbol: tokenA.symbol,
+        amount: 3000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
+    done();
+  });
+
+  it('should not create a token with the reserved HTR symbol', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Hathor',
+        symbol: 'HTR',
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.error)
+      .toContain('Invalid token name');
+    done();
+  });
+
+  it('should create a token successfully', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenA.name,
+        symbol: tokenA.symbol,
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success)
+      .toBe(true);
+    expect(response.body.hash)
+      .toBeDefined();
+    done();
+  });
+
+  it('should send the created tokens to the correct address', async done => {
+    const amountTokens = getRandomInt(100, 200);
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenB.name,
+        symbol: tokenB.symbol,
+        amount: amountTokens,
+        address: await wallet1.getAddressAt(9)
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    const transaction = response.body;
+    expect(transaction.success)
+      .toBe(true);
+
+    const addr8 = await wallet1.getAddressInfo(9, transaction.hash);
+    expect(addr8.total_amount_received)
+      .toBe(amountTokens);
+    done();
+  });
+
+  it('should send the change to the correct address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenB.name,
+        symbol: tokenB.symbol,
+        amount: 100,
+        change_address: await wallet2.getAddressAt(5)
+      })
+      .set({ 'x-wallet-id': wallet2.walletId });
+
+    const transaction = response.body;
+    expect(transaction.success)
+      .toBe(true);
+    const customTokenOutputIndex = TestUtils.getOutputIndexFromTx(transaction, 100);
+
+    // If the custom token output is 0, the HTR will be on the output index 1. And vice-versa.
+    const htrOutputIndex = customTokenOutputIndex === 1 ? 0 : 1;
+    const htrChange = transaction.outputs[htrOutputIndex].value;
+
+    const addr8 = await wallet1.getAddressInfo(5);
+    expect(addr8.total_amount_received)
+      .toBe(htrChange);
+    done();
+  });
+});

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -56,6 +56,37 @@ describe('create token', () => {
     done();
   });
 
+  it('should reject a name with more than 30 characters', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Name input with more than 30 characters',
+        symbol: tokenA.symbol,
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('maximum size');
+    done();
+  });
+
+  // The result is an error with the message "maximum size", but consumes the funds. Must be fixed.
+  it.skip('should reject a symbol with more than 5 characters', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: tokenA.name,
+        symbol: 'TKABCD',
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('maximum size');
+    done();
+  });
+
   it('should reject an invalid destination address', async done => {
     const response = await TestUtils.request
       .post('/wallet/create-token')

--- a/__tests__/integration/docker-compose.yml
+++ b/__tests__/integration/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - fullnode
     ports:
-      - "8034:8034" # Not mandatory to keep these ports open, but helpful for developer machine debugging
+      - "8034:8034" # Not mandatory to keep this port open, but helpful for developer machine debugging
       - "8035:8035"
     command: [
       "http://fullnode:8080",

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -132,23 +132,6 @@ describe('melt tokens', () => {
     done();
   });
 
-  // The application is incorrectly allowing a deposit address outside the wallet
-  it.skip('should not melt with a deposit_address outside the wallet', async done => {
-    const response = await TestUtils.request
-      .post('/wallet/melt-tokens')
-      .send({
-        token: tokenA.uid,
-        deposit_address: WALLET_CONSTANTS.genesis.addresses[4],
-        amount: 200
-      })
-      .set({ 'x-wallet-id': wallet1.walletId });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(false);
-    expect(response.text).toContain('invalid');
-    done();
-  });
-
   // The application is incorrectly allowing a change address outside the wallet
   it.skip('should not melt with a change_address outside the wallet', async done => {
     const response = await TestUtils.request
@@ -237,9 +220,6 @@ describe('melt tokens', () => {
     const addr5tka = await wallet1.getAddressInfo(5, tokenA.uid);
     expect(addr5htr.total_amount_available).toBe(1);
     expect(addr5tka.total_amount_available).toBe(0);
-
-    const balance1 = await wallet1.getBalance(tokenA.uid);
-    expect(balance1.available).toBe(500 - 100);
 
     const balance1htr = await wallet1.getBalance();
     const balance1tka = await wallet1.getBalance(tokenA.uid);

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -16,7 +16,7 @@ describe('melt tokens', () => {
     await WalletHelper.startMultipleWalletsForTest([wallet1]);
 
     // Creating a token for the tests
-    await wallet1.injectFunds(10, 0, { doNotWait: true });
+    await wallet1.injectFunds(10, 0);
     const tkAtx = await wallet1.createToken({
       name: tokenA.name,
       symbol: tokenA.symbol,
@@ -55,7 +55,7 @@ describe('melt tokens', () => {
       .post('/wallet/melt-tokens')
       .send({
         token: tokenA.uid,
-        amount: 'invalidVamount'
+        amount: 'invalidAmount'
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -110,6 +110,8 @@ describe('melt tokens', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
 
     const balanceResult = await TestUtils.request
       .get('/wallet/balance')

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -1,4 +1,4 @@
-import { TestUtils } from './utils/test-utils-integration';
+import { TestUtils, WALLET_CONSTANTS } from './utils/test-utils-integration';
 import { WalletHelper } from './utils/wallet-helper';
 
 describe('melt tokens', () => {
@@ -25,6 +25,11 @@ describe('melt tokens', () => {
       change_address: await wallet1.getAddressAt(0)
     });
     tokenA.uid = tkAtx.hash;
+
+    /**
+     * Status:
+     * wallet1[0]: 2 HTR , 800 TKA
+     */
   });
 
   afterAll(async () => {
@@ -65,6 +70,102 @@ describe('melt tokens', () => {
     done();
   });
 
+  it('should not melt with zero amount', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 0
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('amount');
+    done();
+  });
+
+  it('should not melt with a negative amount', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: -1
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('amount');
+    done();
+  });
+
+  it('should not melt with an invalid deposit_address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        deposit_address: 'invalidAddress',
+        amount: 200
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
+    done();
+  });
+
+  it('should not melt with an invalid change_address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 200,
+        change_address: 'invalidAddress'
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
+    done();
+  });
+
+  // The application is incorrectly allowing a deposit address outside the wallet
+  it.skip('should not melt with a deposit_address outside the wallet', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        deposit_address: WALLET_CONSTANTS.genesis.addresses[4],
+        amount: 200
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
+    done();
+  });
+
+  // The application is incorrectly allowing a change address outside the wallet
+  it.skip('should not melt with a change_address outside the wallet', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 200,
+        change_address: WALLET_CONSTANTS.genesis.addresses[4]
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
+    done();
+  });
+
   // Insufficient funds
 
   it('should not melt with insuficcient tokens', async done => {
@@ -85,27 +186,14 @@ describe('melt tokens', () => {
 
   // Success
 
-  it('should melt with correct parameters', async done => {
+  it('should melt with address and change address', async done => {
     const response = await TestUtils.request
       .post('/wallet/melt-tokens')
       .send({
         token: tokenA.uid,
-        address: await wallet1.getAddressAt(1),
-        amount: 300
-      })
-      .set({ 'x-wallet-id': wallet1.walletId });
-
-    expect(response.body.success).toBe(true);
-    done();
-  });
-
-  it('should melt all the tokens', async done => {
-    const response = await TestUtils.request
-      .post('/wallet/melt-tokens')
-      .send({
-        token: tokenA.uid,
-        address: await wallet1.getAddressAt(1),
-        amount: 500
+        amount: 300,
+        deposit_address: await wallet1.getAddressAt(3),
+        change_address: await wallet1.getAddressAt(4),
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -113,12 +201,142 @@ describe('melt tokens', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const balanceResult = await TestUtils.request
-      .get('/wallet/balance')
-      .query({ token: tokenA.uid })
+    const addr3htr = await wallet1.getAddressInfo(3);
+    const addr3tka = await wallet1.getAddressInfo(3, tokenA.uid);
+    expect(addr3htr.total_amount_available).toBe(3)
+    expect(addr3tka.total_amount_available).toBe(0)
+
+    const addr4htr = await wallet1.getAddressInfo(4);
+    const addr4tka = await wallet1.getAddressInfo(4, tokenA.uid);
+    expect(addr4htr.total_amount_available).toBe(0)
+    expect(addr4tka.total_amount_available).toBe(500)
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(2 + 3);
+    expect(balance1tka.available).toBe(800 - 300);
+
+    done();
+  });
+
+  it('should melt with deposit address only', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 100,
+        deposit_address: await wallet1.getAddressAt(5),
+      })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(balanceResult.body.available).toBe(0);
+    expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
+
+    const addr5htr = await wallet1.getAddressInfo(5);
+    const addr5tka = await wallet1.getAddressInfo(5, tokenA.uid);
+    expect(addr5htr.total_amount_available).toBe(1);
+    expect(addr5tka.total_amount_available).toBe(0);
+
+    const balance1 = await wallet1.getBalance(tokenA.uid);
+    expect(balance1.available).toBe(500 - 100);
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(2 + 3 + 1);
+    expect(balance1tka.available).toBe(800 - 300 - 100);
+
+    done();
+  });
+
+  it('should melt with change address only', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 100,
+        change_address: await wallet1.getAddressAt(7),
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
+
+    const addr7htr = await wallet1.getAddressInfo(7);
+    const addr7tka = await wallet1.getAddressInfo(7, tokenA.uid);
+    expect(addr7htr.total_amount_available).toBe(0);
+    expect(addr7tka.total_amount_available).toBe(300);
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(2 + 3 + 1 + 1);
+    expect(balance1tka.available).toBe(800 - 300 - 100 - 100);
+
+    done();
+  });
+
+  it('should melt with mandatory parameters', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(2 + 3 + 1 + 1 + 1); // 8
+    expect(balance1tka.available).toBe(800 - 300 - 100 - 100 - 100); // 200
+
+    done();
+  });
+
+  it('should not retrieve funds when melting below 100 tokens', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 50
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(8);
+    expect(balance1tka.available).toBe(150);
+
+    done();
+  });
+
+  it('should retrieve funds rounded down when not melting multiples of 100', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 150
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
+
+    const balance1htr = await wallet1.getBalance();
+    const balance1tka = await wallet1.getBalance(tokenA.uid);
+    expect(balance1htr.available).toBe(9);
+    expect(balance1tka.available).toBe(0);
+
     done();
   });
 });

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -203,13 +203,13 @@ describe('melt tokens', () => {
 
     const addr3htr = await wallet1.getAddressInfo(3);
     const addr3tka = await wallet1.getAddressInfo(3, tokenA.uid);
-    expect(addr3htr.total_amount_available).toBe(3)
-    expect(addr3tka.total_amount_available).toBe(0)
+    expect(addr3htr.total_amount_available).toBe(3);
+    expect(addr3tka.total_amount_available).toBe(0);
 
     const addr4htr = await wallet1.getAddressInfo(4);
     const addr4tka = await wallet1.getAddressInfo(4, tokenA.uid);
-    expect(addr4htr.total_amount_available).toBe(0)
-    expect(addr4tka.total_amount_available).toBe(500)
+    expect(addr4htr.total_amount_available).toBe(0);
+    expect(addr4tka.total_amount_available).toBe(500);
 
     const balance1htr = await wallet1.getBalance();
     const balance1tka = await wallet1.getBalance(tokenA.uid);

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -1,0 +1,133 @@
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('melt tokens', () => {
+  let wallet1;
+  const tokenA = {
+    name: 'Token A',
+    symbol: 'TKA',
+    uid: null
+  };
+
+  beforeAll(async () => {
+    wallet1 = new WalletHelper('melt-token-1');
+
+    // Starting the wallets
+    await WalletHelper.startMultipleWalletsForTest([wallet1]);
+
+    // Creating a token for the tests
+    await wallet1.injectFunds(10, 0, { doNotWait: true });
+    const tkAtx = await wallet1.createToken({
+      name: tokenA.name,
+      symbol: tokenA.symbol,
+      amount: 800,
+      address: await wallet1.getAddressAt(0),
+      change_address: await wallet1.getAddressAt(0)
+    });
+    tokenA.uid = tkAtx.hash;
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+  });
+
+  // Testing failures first, that do not cause side-effects on the blockchain
+
+  it('should not melt an invalid token', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: 'invalidToken',
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+
+    // Even though the result is correct, the error thrown is not related. Should be fixed later.
+    // expect(response.body.error).toContain('invalid');
+    done();
+  });
+
+  it('should not melt with an invalid amount', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        amount: 'invalidVamount'
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.text)
+      .toContain('invalid');
+    done();
+  });
+
+  // Insufficient funds
+
+  it('should not melt with insuficcient tokens', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('enough inputs to melt');
+    done();
+  });
+
+  // Success
+
+  it('should melt with correct parameters', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 300
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success)
+      .toBe(true);
+    done();
+  });
+
+  it('should melt all the tokens', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/melt-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 500
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success)
+      .toBe(true);
+
+    const balanceResult = await TestUtils.request
+      .get('/wallet/balance')
+      .query({ token: tokenA.uid })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(balanceResult.body.available)
+      .toBe(0);
+    done();
+  });
+});

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -151,7 +151,7 @@ describe('melt tokens', () => {
 
   // Insufficient funds
 
-  it('should not melt with insuficcient tokens', async done => {
+  it('should not melt with insufficient tokens', async done => {
     const response = await TestUtils.request
       .post('/wallet/melt-tokens')
       .send({

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -42,10 +42,8 @@ describe('melt tokens', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
 
     // Even though the result is correct, the error thrown is not related. Should be fixed later.
     // expect(response.body.error).toContain('invalid');
@@ -61,12 +59,9 @@ describe('melt tokens', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.text)
-      .toContain('invalid');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
     done();
   });
 
@@ -82,12 +77,9 @@ describe('melt tokens', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('enough inputs to melt');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('enough inputs to melt');
     done();
   });
 
@@ -103,8 +95,7 @@ describe('melt tokens', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(true);
+    expect(response.body.success).toBe(true);
     done();
   });
 
@@ -118,16 +109,14 @@ describe('melt tokens', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(true);
+    expect(response.body.success).toBe(true);
 
     const balanceResult = await TestUtils.request
       .get('/wallet/balance')
       .query({ token: tokenA.uid })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(balanceResult.body.available)
-      .toBe(0);
+    expect(balanceResult.body.available).toBe(0);
     done();
   });
 });

--- a/__tests__/integration/melt-tokens.test.js
+++ b/__tests__/integration/melt-tokens.test.js
@@ -50,7 +50,7 @@ describe('melt tokens', () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(false);
 
-    // Even though the result is correct, the error thrown is not related. Should be fixed later.
+    // TODO: Even though the result is correct, the error thrown is not related.
     // expect(response.body.error).toContain('invalid');
     done();
   });

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -165,7 +165,7 @@ describe('mint token', () => {
     await TestUtils.pauseForWsUpdate();
 
     const addr1 = await wallet1.getAddressInfo(1, tokenA.uid);
-    expect(addr1.total_amount_available).toBe(50)
+    expect(addr1.total_amount_available).toBe(50);
 
     done();
   });
@@ -182,19 +182,18 @@ describe('mint token', () => {
 
     const transaction = response.body;
     expect(transaction.success).toBe(true);
-    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0)
-    const htrChange = transaction.outputs[htrOutputIndex].value
+    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0);
+    const htrChange = transaction.outputs[htrOutputIndex].value;
 
     await TestUtils.pauseForWsUpdate();
 
     const addr10 = await wallet1.getAddressInfo(10);
     expect(addr10.total_amount_received).toBe(htrChange);
 
-    const tkaBalance = await wallet1.getBalance(tokenA.uid)
-    expect(tkaBalance.available).toBe(500 + 50 + 60)
+    const tkaBalance = await wallet1.getBalance(tokenA.uid);
+    expect(tkaBalance.available).toBe(500 + 50 + 60);
     done();
   });
-
 
   it('should mint with only mandatory parameters', async done => {
     const destinationAddress = await wallet1.getNextAddress();
@@ -212,14 +211,17 @@ describe('mint token', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const addrNew = await TestUtils.getAddressInfo(destinationAddress, wallet1.walletId, tokenA.uid);
-    expect(addrNew.total_amount_available).toBe(70)
+    const addrNew = await TestUtils.getAddressInfo(
+      destinationAddress,
+      wallet1.walletId,
+      tokenA.uid
+    );
+    expect(addrNew.total_amount_available).toBe(70);
 
-    const tkaBalance = await wallet1.getBalance(tokenA.uid)
-    expect(tkaBalance.available).toBe(500 + 50 + 60 + 70)
+    const tkaBalance = await wallet1.getBalance(tokenA.uid);
+    expect(tkaBalance.available).toBe(500 + 50 + 60 + 70);
     done();
   });
-
 
   it('should mint with all parameters', async done => {
     // By default, will mint tokens into the next unused address
@@ -233,18 +235,18 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    const transaction = response.body
+    const transaction = response.body;
     expect(transaction.success).toBe(true);
-    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0)
-    const htrChange = transaction.outputs[htrOutputIndex].value
+    const htrOutputIndex = transaction.outputs.findIndex(o => o.token_data === 0);
+    const htrChange = transaction.outputs[htrOutputIndex].value;
 
     await TestUtils.pauseForWsUpdate();
 
-    const addr15 = await wallet1.getAddressInfo(15, tokenA.uid)
-    expect(addr15.total_amount_available).toBe(80)
+    const addr15 = await wallet1.getAddressInfo(15, tokenA.uid);
+    expect(addr15.total_amount_available).toBe(80);
 
-    const addr14 = await wallet1.getAddressInfo(14)
-    expect(addr14.total_amount_available).toBe(htrChange)
+    const addr14 = await wallet1.getAddressInfo(14);
+    expect(addr14.total_amount_available).toBe(htrChange);
     done();
   });
 });

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -45,7 +45,7 @@ describe('mint token', () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(false);
 
-    // Even though the result is correct, the error thrown is not related. Should be fixed later.
+    // TODO: Even though the result is correct, the error thrown is not related.
     // expect(response.body.message).toContain('invalid');
     done();
   });

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -97,23 +97,6 @@ describe('mint token', () => {
     done();
   });
 
-  // The application is allowing minting for an address outside the wallet
-  it.skip('should not mint for addresses outside the wallet', async done => {
-    const response = await TestUtils.request
-      .post('/wallet/mint-tokens')
-      .send({
-        token: tokenA.uid,
-        address: WALLET_CONSTANTS.genesis.addresses[3],
-        amount: 100
-      })
-      .set({ 'x-wallet-id': wallet1.walletId });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toContain('address');
-    done();
-  });
-
   // The application is allowing a change_address outside the wallet
   it.skip('should not mint with change_address outside the wallet', async done => {
     const response = await TestUtils.request

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -116,7 +116,7 @@ describe('mint token', () => {
 
   // Insufficient funds
 
-  it('should not mint with insuficcient funds', async done => {
+  it('should not mint with insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/mint-tokens')
       .send({

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -43,10 +43,8 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
 
     // Even though the result is correct, the error thrown is not related. Should be fixed later.
     // expect(response.body.message).toContain('invalid');
@@ -63,12 +61,9 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('base58');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('base58');
     done();
   });
 
@@ -83,12 +78,9 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('invalid');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
     done();
   });
 
@@ -102,12 +94,9 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.text)
-      .toContain('invalid');
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.text).toContain('invalid');
     done();
   });
 
@@ -123,12 +112,9 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('HTR funds');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('HTR funds');
     done();
   });
 
@@ -144,8 +130,7 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(true);
+    expect(response.body.success).toBe(true);
     done();
   });
 
@@ -160,12 +145,10 @@ describe('mint token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(true);
+    expect(response.body.success).toBe(true);
 
     const addr10 = await wallet1.getAddressInfo(10);
-    expect(addr10.total_amount_received)
-      .toBe(1);
+    expect(addr10.total_amount_received).toBe(1);
     done();
   });
 });

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -16,7 +16,7 @@ describe('mint token', () => {
     await WalletHelper.startMultipleWalletsForTest([wallet1]);
 
     // Creating a token for the tests
-    await wallet1.injectFunds(10, 0, { doNotWait: true });
+    await wallet1.injectFunds(10, 0);
     const tkAtx = await wallet1.createToken({
       name: tokenA.name,
       symbol: tokenA.symbol,
@@ -146,6 +146,8 @@ describe('mint token', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     expect(response.body.success).toBe(true);
+
+    await TestUtils.pauseForWsUpdate();
 
     const addr10 = await wallet1.getAddressInfo(10);
     expect(addr10.total_amount_received).toBe(1);

--- a/__tests__/integration/mint-tokens.test.js
+++ b/__tests__/integration/mint-tokens.test.js
@@ -1,0 +1,171 @@
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('mint token', () => {
+  let wallet1;
+  const tokenA = {
+    name: 'Token A',
+    symbol: 'TKA',
+    uid: null
+  };
+
+  beforeAll(async () => {
+    wallet1 = new WalletHelper('mint-token-1');
+
+    // Starting the wallets
+    await WalletHelper.startMultipleWalletsForTest([wallet1]);
+
+    // Creating a token for the tests
+    await wallet1.injectFunds(10, 0, { doNotWait: true });
+    const tkAtx = await wallet1.createToken({
+      name: tokenA.name,
+      symbol: tokenA.symbol,
+      amount: 500,
+      address: await wallet1.getAddressAt(0),
+      change_address: await wallet1.getAddressAt(0)
+    });
+    tokenA.uid = tkAtx.hash;
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+  });
+
+  // Testing failures first, that do not cause side-effects on the blockchain
+
+  it('should not mint an invalid token', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: 'invalidToken',
+        address: await wallet1.getAddressAt(1),
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+
+    // Even though the result is correct, the error thrown is not related. Should be fixed later.
+    // expect(response.body.message).toContain('invalid');
+    done();
+  });
+
+  it('should not mint with an invalid address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: 'invalidAddress',
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('base58');
+    done();
+  });
+
+  it('should not mint with an invalid change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        change_address: 'invalidAddress',
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('invalid');
+    done();
+  });
+
+  it('should not mint with an invalid amount', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 'invalidVamount'
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.text)
+      .toContain('invalid');
+    done();
+  });
+
+  // Insufficient funds
+
+  it('should not mint with insuficcient funds', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 1000
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('HTR funds');
+    done();
+  });
+
+  // Success
+
+  it('should mint without a change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        amount: 300
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success)
+      .toBe(true);
+    done();
+  });
+
+  it('should mint with a change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/mint-tokens')
+      .send({
+        token: tokenA.uid,
+        address: await wallet1.getAddressAt(1),
+        change_address: await wallet1.getAddressAt(10),
+        amount: 100
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success)
+      .toBe(true);
+
+    const addr10 = await wallet1.getAddressInfo(10);
+    expect(addr10.total_amount_received)
+      .toBe(1);
+    done();
+  });
+});

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -36,11 +36,11 @@ describe('send tx (HTR)', () => {
       await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2, wallet3]);
 
       // Funds for single input/output tests
-      const fundTxObj1 = await wallet1.injectFunds(1000, 0, { doNotWait: true });
+      const fundTxObj1 = await wallet1.injectFunds(1000, 0);
       // Funds for multiple input/output tests
-      const fundTxObj2 = await wallet3.injectFunds(1000, 0, { doNotWait: true });
-      const fundTxObj3 = await wallet3.injectFunds(1000, 1, { doNotWait: true });
-      const fundTxObj4 = await wallet3.injectFunds(1000, 4, { doNotWait: true });
+      const fundTxObj2 = await wallet3.injectFunds(1000, 0);
+      const fundTxObj3 = await wallet3.injectFunds(1000, 1);
+      const fundTxObj4 = await wallet3.injectFunds(1000, 4);
 
       fundTx1.hash = fundTxObj1.hash;
       fundTx1.index = TestUtils.getOutputIndexFromTx(fundTxObj1, 1000);
@@ -52,7 +52,7 @@ describe('send tx (HTR)', () => {
       fundTx4.index = TestUtils.getOutputIndexFromTx(fundTxObj4, 1000);
 
       // Awaiting for updated balances to be received by the websocket
-      await TestUtils.delay(1000);
+      await TestUtils.pauseForWsUpdate();
     } catch (err) {
       TestUtils.logError(err.stack);
     }
@@ -365,9 +365,6 @@ describe('send tx (HTR)', () => {
   });
 
   it('should send with only the filterAddress', async done => {
-    // Waiting for transactions to settle and spending the 20 HTR tokens above back to wallet1
-    await TestUtils.delay(1000);
-
     const tx = await wallet2.sendTx({
       fullObject: {
         inputs: [{
@@ -405,6 +402,8 @@ describe('send tx (HTR)', () => {
     expect(tx.success).toBe(true);
     expect(tx.hash).toBeDefined();
 
+    await TestUtils.pauseForWsUpdate();
+
     const [addr1, addr2] = await Promise.all([
       wallet2.getAddressInfo(1),
       wallet2.getAddressInfo(2),
@@ -432,6 +431,8 @@ describe('send tx (HTR)', () => {
     });
 
     expect(tx.hash).toBeDefined();
+
+    await TestUtils.pauseForWsUpdate();
 
     const addr6 = await wallet2.getAddressInfo(6);
     const addr2 = await wallet3.getAddressInfo(2);
@@ -465,6 +466,8 @@ describe('send tx (HTR)', () => {
     expect(tx.success).toBe(true);
     expect(tx.hash).toBeDefined();
 
+    await TestUtils.pauseForWsUpdate();
+
     const addr3 = await wallet2.getAddressInfo(3);
     expect(addr3.total_amount_received).toBe(2000);
     expect(addr3.total_amount_sent).toBe(2000);
@@ -489,6 +492,8 @@ describe('send tx (HTR)', () => {
 
     expect(tx.success).toBe(true);
     expect(tx.hash).toBeDefined();
+
+    await TestUtils.pauseForWsUpdate();
 
     const addr5 = await wallet2.getAddressInfo(5);
     expect(addr5.total_amount_received).toBe(0);
@@ -518,6 +523,8 @@ describe('send tx (HTR)', () => {
 
     expect(tx.success).toBe(true);
     expect(tx.hash).toBeDefined();
+
+    await TestUtils.pauseForWsUpdate();
 
     const addr7 = await wallet2.getAddressInfo(10);
     expect(addr7.total_amount_received).toBe(760);
@@ -562,9 +569,9 @@ describe('send tx (custom tokens)', () => {
     await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2, wallet3]);
 
     // Funds for single input/output tests - 1000 HTR + 2000 custom A
-    await wallet1.injectFunds(1020, 0, { doNotWait: true });
+    await wallet1.injectFunds(1020, 0);
     // Funds for multiple token tests - 990 HTR + 1000 custom B
-    await wallet3.injectFunds(1000, 0, { doNotWait: true });
+    await wallet3.injectFunds(1000, 0);
     const tokenCreationA = await wallet1.createToken({
       name: tokenA.name,
       symbol: tokenA.symbol,
@@ -601,9 +608,6 @@ describe('send tx (custom tokens)', () => {
     tokenB.uid = tokenCreationB.hash;
     fundTx2.hash = tokenCreationB.hash;
     fundTx2.index = TestUtils.getOutputIndexFromTx(tokenCreationB, 990);
-
-    // Awaiting for balances to be updated via websocket
-    await TestUtils.delay(1000);
   });
 
   afterAll(async () => {

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -246,8 +246,8 @@ describe('send tx (HTR)', () => {
     done();
   });
 
-  // Insuficcient funds
-  it('should reject for insuficcient funds', async done => {
+  // insufficient funds
+  it('should reject for insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -309,7 +309,7 @@ describe('send tx (HTR)', () => {
     done();
   });
 
-  it('should reject for insuficcient funds on queryAddress', async done => {
+  it('should reject for insufficient funds on queryAddress', async done => {
     // Wallet1 has enough funds, but none of them are on index 5
     const response = await TestUtils.request
       .post('/wallet/send-tx')
@@ -331,7 +331,7 @@ describe('send tx (HTR)', () => {
     done();
   });
 
-  it('should reject for insuficcient funds on input', async done => {
+  it('should reject for insufficient funds on input', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -817,8 +817,8 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  // Insuficcient funds
-  it('should reject a transaction with insuficcient funds', async done => {
+  // insufficient funds
+  it('should reject a transaction with insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -834,7 +834,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a single-input transaction with insuficcient funds', async done => {
+  it('should reject a single-input transaction with insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -857,7 +857,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a multi-input transaction with insuficcient funds', async done => {
+  it('should reject a multi-input transaction with insufficient funds', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -884,7 +884,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a multi-input, multi token transaction with insuficcient funds (custom)', async done => {
+  it('should reject a multi-input, multi token transaction with insufficient funds (custom)', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -914,7 +914,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a multi-input, multi token transaction with insuficcient funds (htr)', async done => {
+  it('should reject a multi-input, multi token transaction with insufficient funds (htr)', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -78,12 +78,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -102,12 +99,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -123,14 +117,10 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('invalid');
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
     done();
   });
 
@@ -150,14 +140,10 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('invalid');
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
     done();
   });
 
@@ -180,14 +166,10 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.error)
-      .toContain('invalid');
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
     done();
   });
 
@@ -203,15 +185,11 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
     const errorElement = response.body.error[0];
-    expect(errorElement.param)
-      .toBe('change_address');
-    expect(errorElement.msg)
-      .toContain('Invalid');
+    expect(errorElement.param).toBe('change_address');
+    expect(errorElement.msg).toContain('Invalid');
     done();
   });
 
@@ -226,16 +204,11 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body)
-      .toHaveProperty('error');
-    expect(response.body.error[0].msg)
-      .toContain('Invalid');
+    expect(response.status).toBe(400);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body).toHaveProperty('error');
+    expect(response.body.error[0].msg).toContain('Invalid');
     done();
   });
 
@@ -250,10 +223,8 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(400);
-    expect(response.body.error[0].msg)
-      .toContain('Invalid');
+    expect(response.status).toBe(400);
+    expect(response.body.error[0].msg).toContain('Invalid');
     done();
   });
 
@@ -269,12 +240,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet2.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -296,12 +264,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -320,12 +285,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -345,12 +307,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -366,12 +325,9 @@ describe('send tx (HTR)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status)
-      .toBe(200);
-    expect(response.body.hash)
-      .toBeUndefined();
-    expect(response.body.success)
-      .toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
     done();
   });
 
@@ -387,10 +343,8 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash)
-      .toBeDefined();
-    expect(tx.success)
-      .toBe(true);
+    expect(tx.hash).toBeDefined();
+    expect(tx.success).toBe(true);
     done();
   });
 
@@ -405,10 +359,8 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash)
-      .toBeDefined();
-    expect(tx.success)
-      .toBe(true);
+    expect(tx.hash).toBeDefined();
+    expect(tx.success).toBe(true);
     done();
   });
 
@@ -429,10 +381,8 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash)
-      .toBeDefined();
-    expect(tx.success)
-      .toBe(true);
+    expect(tx.hash).toBeDefined();
+    expect(tx.success).toBe(true);
     done();
   });
 
@@ -452,19 +402,15 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
 
     const [addr1, addr2] = await Promise.all([
       wallet2.getAddressInfo(1),
       wallet2.getAddressInfo(2),
     ]);
-    expect(addr1.total_amount_received)
-      .toBe(20);
-    expect(addr2.total_amount_received)
-      .toBe(30);
+    expect(addr1.total_amount_received).toBe(20);
+    expect(addr2.total_amount_received).toBe(30);
     done();
   });
 
@@ -485,16 +431,13 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.hash).toBeDefined();
 
     const addr6 = await wallet2.getAddressInfo(6);
     const addr2 = await wallet3.getAddressInfo(2);
 
-    expect(addr6.total_amount_received)
-      .toBe(1500);
-    expect(addr2.total_amount_received)
-      .toBe(500);
+    expect(addr6.total_amount_received).toBe(1500);
+    expect(addr2.total_amount_received).toBe(500);
 
     tx5.hash = tx.hash;
     tx5.index = TestUtils.getOutputIndexFromTx(tx, 500);
@@ -519,20 +462,15 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
 
     const addr3 = await wallet2.getAddressInfo(3);
-    expect(addr3.total_amount_received)
-      .toBe(2000);
-    expect(addr3.total_amount_sent)
-      .toBe(2000);
+    expect(addr3.total_amount_received).toBe(2000);
+    expect(addr3.total_amount_sent).toBe(2000);
 
     const addr4 = await wallet1.getAddressInfo(4);
-    expect(addr4.total_amount_received)
-      .toBe(1100);
+    expect(addr4.total_amount_received).toBe(1100);
 
     done();
   });
@@ -549,14 +487,11 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
 
     const addr5 = await wallet2.getAddressInfo(5);
-    expect(addr5.total_amount_received)
-      .toBe(0);
+    expect(addr5.total_amount_received).toBe(0);
 
     done();
   });
@@ -581,18 +516,14 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
 
     const addr7 = await wallet2.getAddressInfo(10);
-    expect(addr7.total_amount_received)
-      .toBe(760);
+    expect(addr7.total_amount_received).toBe(760);
 
     const addr8 = await wallet2.getAddressInfo(11);
-    expect(addr8.total_amount_received)
-      .toBe(740);
+    expect(addr8.total_amount_received).toBe(740);
     done();
   });
 });
@@ -699,10 +630,8 @@ describe('send tx (custom tokens)', () => {
         }
       })
       .set({ 'x-wallet-id': wallet1.walletId });
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -723,10 +652,8 @@ describe('send tx (custom tokens)', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     // Currently ignoring the wrong name. To be fixed later
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -752,10 +679,8 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -776,10 +701,8 @@ describe('send tx (custom tokens)', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     // Currently ignoring the wrong symbol. To be fixed later
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -795,10 +718,8 @@ describe('send tx (custom tokens)', () => {
         token: tokenA
       })
       .set({ 'x-wallet-id': wallet1.walletId });
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -820,10 +741,8 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -849,10 +768,8 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -881,10 +798,8 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -913,10 +828,8 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.body.success)
-      .toBe(false);
-    expect(response.body.hash)
-      .toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.hash).toBeUndefined();
     done();
   });
 
@@ -943,10 +856,8 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
     tkaTx2.hash = tx.hash;
     tkaTx2.index = TestUtils.getOutputIndexFromTx(tx, 800);
 
@@ -974,10 +885,8 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
 
     // All 2000 TKA are now on Wallet2
     done();
@@ -997,10 +906,8 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
     done();
   });
 
@@ -1059,10 +966,8 @@ describe('send tx (custom tokens)', () => {
       fullObject: consolidateTxOptions
     });
 
-    expect(consolidateTx.success)
-      .toBe(true);
-    expect(consolidateTx.hash)
-      .toBeDefined();
+    expect(consolidateTx.success).toBe(true);
+    expect(consolidateTx.hash).toBeDefined();
     done();
   });
 
@@ -1093,10 +998,8 @@ describe('send tx (custom tokens)', () => {
       }
     });
 
-    expect(tx.success)
-      .toBe(true);
-    expect(tx.hash)
-      .toBeDefined();
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
     done();
   });
 });

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -362,8 +362,8 @@ describe('send tx (HTR)', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     expect(response.status).toBe(400);
-    expect(response.text).toContain('Invalid')
-    expect(response.text).toContain('input')
+    expect(response.text).toContain('Invalid');
+    expect(response.text).toContain('input');
     done();
   });
 
@@ -384,7 +384,7 @@ describe('send tx (HTR)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const destination0 = await wallet2.getAddressInfo(0)
+    const destination0 = await wallet2.getAddressInfo(0);
     expect(destination0.total_amount_available).toBe(10);
 
     done();
@@ -406,10 +406,10 @@ describe('send tx (HTR)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const destination = await wallet2.getAddressInfo(0)
+    const destination = await wallet2.getAddressInfo(0);
     expect(destination.total_amount_available).toBe(20);
 
-    const changeAddr = await wallet1.getAddressInfo(0)
+    const changeAddr = await wallet1.getAddressInfo(0);
     const txSummary = TestUtils.getOutputSummaryHtr(tx, 10);
     expect(changeAddr.total_amount_available).toBe(txSummary.change.value);
 
@@ -417,10 +417,10 @@ describe('send tx (HTR)', () => {
   });
 
   it('should send with only the filterAddress', async done => {
-    const inputAddrBefore = await wallet2.getAddressInfo(0)
-    const destinationAddrBefore = await wallet1.getAddressInfo(0)
-    const sourceBeforeTx = inputAddrBefore.total_amount_available
-    const destinationBeforeTx = destinationAddrBefore.total_amount_available
+    const inputAddrBefore = await wallet2.getAddressInfo(0);
+    const destinationAddrBefore = await wallet1.getAddressInfo(0);
+    const sourceBeforeTx = inputAddrBefore.total_amount_available;
+    const destinationBeforeTx = destinationAddrBefore.total_amount_available;
 
     const tx = await wallet2.sendTx({
       fullObject: {
@@ -440,17 +440,17 @@ describe('send tx (HTR)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const inputAddrAfter = await wallet2.getAddressInfo(0)
-    const destinationAddrAfter = await wallet1.getAddressInfo(0)
-    expect(inputAddrAfter.total_amount_available).toBe(sourceBeforeTx - 20)
-    expect(destinationAddrAfter.total_amount_available).toBe(destinationBeforeTx + 20)
+    const inputAddrAfter = await wallet2.getAddressInfo(0);
+    const destinationAddrAfter = await wallet1.getAddressInfo(0);
+    expect(inputAddrAfter.total_amount_available).toBe(sourceBeforeTx - 20);
+    expect(destinationAddrAfter.total_amount_available).toBe(destinationBeforeTx + 20);
 
     done();
   });
 
   it('should send with two outputs', async done => {
-    const destination1Before = await wallet2.getAddressInfo(1)
-    const destination2Before = await wallet1.getAddressInfo(2)
+    const destination1Before = await wallet2.getAddressInfo(1);
+    const destination2Before = await wallet1.getAddressInfo(2);
 
     const tx = await wallet1.sendTx({
       fullObject: {
@@ -472,8 +472,8 @@ describe('send tx (HTR)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const destination1After = await wallet2.getAddressInfo(1)
-    const destination2After = await wallet2.getAddressInfo(2)
+    const destination1After = await wallet2.getAddressInfo(1);
+    const destination2After = await wallet2.getAddressInfo(2);
     expect(destination1After.total_amount_available)
       .toBe(destination1Before.total_amount_available + 20);
     expect(destination2After.total_amount_available)
@@ -516,7 +516,7 @@ describe('send tx (HTR)', () => {
   it('should send with correct input', async done => {
     // Injecting 2000 HTR on wallet2[3], to ensure the funds would not be available otherwise
     const fundTxObj = await wallet2.injectFunds(2000, 3);
-    const fundTx2 = {
+    const fundTxInput = {
       hash: fundTxObj.hash,
       index: TestUtils.getOutputIndexFromTx(fundTxObj, 2000)
     };
@@ -526,7 +526,7 @@ describe('send tx (HTR)', () => {
 
     const tx = await wallet2.sendTx({
       fullObject: {
-        inputs: [fundTx2],
+        inputs: [fundTxInput],
         outputs: [{
           address: await wallet1.getAddressAt(4),
           value: 1100
@@ -608,7 +608,8 @@ describe('send tx (HTR)', () => {
     done();
   });
 
-  it('should confirm that, if not informed, the change address is the next empty one',
+  it(
+    'should confirm that, if not informed, the change address is the next empty one',
     async done => {
       const nextAddressHash = await wallet1.getNextAddress();
 
@@ -628,7 +629,8 @@ describe('send tx (HTR)', () => {
       expect(changeAddr.total_amount_available).toBe(txSummary.change.value);
 
       done();
-    });
+    }
+  );
 });
 
 describe('send tx (custom tokens)', () => {
@@ -965,15 +967,15 @@ describe('send tx (custom tokens)', () => {
 
     // Checking wallet balances
     const balance2tka = await wallet2.getBalance(tokenA.uid);
-    expect(balance2tka.available).toBe(200)
+    expect(balance2tka.available).toBe(200);
     const balance1tka = await wallet1.getBalance(tokenA.uid);
-    expect(balance1tka.available).toBe(1800)
+    expect(balance1tka.available).toBe(1800);
 
     // Checking specific addresses balances
     const destination = await wallet2.getAddressInfo(0, tokenA.uid);
-    expect(destination.total_amount_available).toBe(200)
+    expect(destination.total_amount_available).toBe(200);
     const change = await wallet1.getAddressInfo(0, tokenA.uid);
-    expect(change.total_amount_available).toBe(800)
+    expect(change.total_amount_available).toBe(800);
     done();
   });
 
@@ -1000,13 +1002,13 @@ describe('send tx (custom tokens)', () => {
     expect(tx.hash).toBeDefined();
 
     const balance2tka = await wallet2.getBalance(tokenA.uid);
-    expect(balance2tka.available).toBe(2000)
+    expect(balance2tka.available).toBe(2000);
 
     const destination = await wallet2.getAddressInfo(0, tokenA.uid);
-    expect(destination.total_amount_available).toBe(2000)
+    expect(destination.total_amount_available).toBe(2000);
 
     const balance1tka = await wallet1.getBalance(tokenA.uid);
-    expect(balance1tka.available).toBe(0)
+    expect(balance1tka.available).toBe(0);
     done();
   });
 
@@ -1030,10 +1032,10 @@ describe('send tx (custom tokens)', () => {
     await TestUtils.pauseForWsUpdate();
 
     const destination = await wallet1.getAddressInfo(0, tokenA.uid);
-    expect(destination.total_amount_available).toBe(2000)
+    expect(destination.total_amount_available).toBe(2000);
 
     const balance2tka = await wallet2.getBalance(tokenA.uid);
-    expect(balance2tka.available).toBe(0)
+    expect(balance2tka.available).toBe(0);
 
     done();
   });
@@ -1098,10 +1100,10 @@ describe('send tx (custom tokens)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const destination3 = await wallet1.getAddressInfo(3, tokenA.uid)
-    const destination4 = await wallet1.getAddressInfo(4, tokenA.uid)
-    expect(destination3.total_amount_available).toBe(1600)
-    expect(destination4.total_amount_available).toBe(400)
+    const destination3 = await wallet1.getAddressInfo(3, tokenA.uid);
+    const destination4 = await wallet1.getAddressInfo(4, tokenA.uid);
+    expect(destination3.total_amount_available).toBe(1600);
+    expect(destination4.total_amount_available).toBe(400);
 
     done();
   });
@@ -1139,16 +1141,16 @@ describe('send tx (custom tokens)', () => {
 
     await TestUtils.pauseForWsUpdate();
 
-    const destination7 = await wallet3.getAddressInfo(7, tokenB.uid)
-    const destination8 = await wallet3.getAddressInfo(8)
-    expect(destination7.total_amount_available).toBe(1000)
-    expect(destination8.total_amount_available).toBe(990)
+    const destination7 = await wallet3.getAddressInfo(7, tokenB.uid);
+    const destination8 = await wallet3.getAddressInfo(8);
+    expect(destination7.total_amount_available).toBe(1000);
+    expect(destination8.total_amount_available).toBe(990);
 
     done();
   });
 
   it('should send a multi-input/token transaction with change address', async done => {
-    const outputIndexTKB = TestUtils.getOutputIndexFromTx(tkbTx1, 1000)
+    const outputIndexTKB = TestUtils.getOutputIndexFromTx(tkbTx1, 1000);
 
     /* We need to have a deep understanding of the wallet and transaction in order to validate
      * its results. First, let's build a "summary" object to help identify the main data here
@@ -1170,7 +1172,7 @@ describe('send tx (custom tokens)', () => {
         changeIndex: null,
         changeAddress: null
       }
-    }
+    };
 
     const nextEmptyAddress = await wallet3.getNextAddress();
 
@@ -1205,28 +1207,26 @@ describe('send tx (custom tokens)', () => {
     const decodedTx = await TestUtils.getDecodedTransaction(tx.hash, wallet3.walletId);
 
     // Analyzing the decoded output data to identify addresses and values
-    for (let index in decodedTx.outputs) {
+    for (const index in decodedTx.outputs) {
       const output = decodedTx.outputs[index];
 
-      // If token_data === 0 , this is a HTR output
       if (output.token_data === 0) {
+        // If token_data === 0 , this is a HTR output
         if (output.value === txOutputSummary.htr.value) {
-          txOutputSummary.htr.index = index
+          txOutputSummary.htr.index = index;
         } else {
-          txOutputSummary.htr.changeIndex = index
-          txOutputSummary.htr.change = output.value
-          txOutputSummary.htr.changeAddress = output.decoded.address
+          txOutputSummary.htr.changeIndex = index;
+          txOutputSummary.htr.change = output.value;
+          txOutputSummary.htr.changeAddress = output.decoded.address;
         }
-      }
-
-      // If token_data === 1, this is a custom toke (TKB) output
-      else if (output.token_data === 1) {
+      } else if (output.token_data === 1) {
+        // If token_data === 1, this is a custom token (TKB) output
         if (output.value === txOutputSummary.tkb.value) {
-          txOutputSummary.tkb.index = index
+          txOutputSummary.tkb.index = index;
         } else {
-          txOutputSummary.tkb.changeIndex = index
-          txOutputSummary.tkb.change = output.value
-          txOutputSummary.tkb.changeAddress = output.decoded.address
+          txOutputSummary.tkb.changeIndex = index;
+          txOutputSummary.tkb.change = output.value;
+          txOutputSummary.tkb.changeAddress = output.decoded.address;
         }
       }
     }
@@ -1234,27 +1234,38 @@ describe('send tx (custom tokens)', () => {
     await TestUtils.pauseForWsUpdate();
 
     // Validating all the outputs' balances
-    const destination10 = await wallet3.getAddressInfo(10, tokenB.uid)
-    const destination11 = await wallet3.getAddressInfo(11)
-    const changeHtr = await TestUtils.getAddressInfo(txOutputSummary.htr.changeAddress, wallet3.walletId)
-    const changeTkb = await TestUtils.getAddressInfo(txOutputSummary.tkb.changeAddress, wallet3.walletId, tokenB.uid)
-    expect(destination10.total_amount_available).toBe(txOutputSummary.tkb.value)
-    expect(destination11.total_amount_available).toBe(txOutputSummary.htr.value)
-    expect(changeHtr.total_amount_available).toBe(txOutputSummary.htr.change)
-    expect(changeTkb.total_amount_available).toBe(txOutputSummary.tkb.change)
+    const destination10 = await wallet3.getAddressInfo(10, tokenB.uid);
+    const destination11 = await wallet3.getAddressInfo(11);
+    const changeHtr = await TestUtils.getAddressInfo(
+      txOutputSummary.htr.changeAddress,
+      wallet3.walletId
+    );
+    const changeTkb = await TestUtils.getAddressInfo(
+      txOutputSummary.tkb.changeAddress,
+      wallet3.walletId,
+      tokenB.uid
+    );
+    expect(destination10.total_amount_available).toBe(txOutputSummary.tkb.value);
+    expect(destination11.total_amount_available).toBe(txOutputSummary.htr.value);
+    expect(changeHtr.total_amount_available).toBe(txOutputSummary.htr.change);
+    expect(changeTkb.total_amount_available).toBe(txOutputSummary.tkb.change);
 
     // Validating that the change addresses are not the same
-    expect(txOutputSummary.htr.changeAddress === txOutputSummary.tkb.changeAddress).toBe(false)
+    expect(txOutputSummary.htr.changeAddress === txOutputSummary.tkb.changeAddress).toBe(false);
 
     // One of these addresses is actually the nextEmptyAddress
-    expect((txOutputSummary.htr.changeAddress === nextEmptyAddress) ||
-           (txOutputSummary.tkb.changeAddress === nextEmptyAddress)).toBe(true)
+    expect((txOutputSummary.htr.changeAddress === nextEmptyAddress)
+           || (txOutputSummary.tkb.changeAddress === nextEmptyAddress)).toBe(true);
 
     // Both these addresses have adjacent indexes: the empty addresses are consumed sequentially
-    const htrChangeIndex = await TestUtils.getAddressIndex(wallet3.walletId,
-      txOutputSummary.htr.changeAddress);
-    const tkbChangeIndex = await TestUtils.getAddressIndex(wallet3.walletId,
-      txOutputSummary.tkb.changeAddress);
+    const htrChangeIndex = await TestUtils.getAddressIndex(
+      wallet3.walletId,
+      txOutputSummary.htr.changeAddress
+    );
+    const tkbChangeIndex = await TestUtils.getAddressIndex(
+      wallet3.walletId,
+      txOutputSummary.tkb.changeAddress
+    );
 
     // Note: this test result may change if the addresses are consumed in a non-linear order
     expect(Math.abs(htrChangeIndex - tkbChangeIndex)).toBe(1);

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -6,11 +6,26 @@ describe('send tx (HTR)', () => {
   let wallet2; // Main destination for test transactions
   let wallet3; // For transactions with more than one input
 
-  const fundTx1 = { hash: null, index: null }; // Fund for auto-input transactions
-  const fundTx2 = { hash: null, index: null }; // Fund for manual input transactions
-  const fundTx3 = { hash: null, index: null }; // Two funds for multi-input transactions
-  const fundTx4 = { hash: null, index: null };
-  const tx5 = { hash: null, index: null }; // This will be executed on a multiple input test
+  const fundTx1 = {
+    hash: null,
+    index: null
+  }; // Fund for auto-input transactions
+  const fundTx2 = {
+    hash: null,
+    index: null
+  }; // Fund for manual input transactions
+  const fundTx3 = {
+    hash: null,
+    index: null
+  }; // Two funds for multi-input transactions
+  const fundTx4 = {
+    hash: null,
+    index: null
+  };
+  const tx5 = {
+    hash: null,
+    index: null
+  }; // This will be executed on a multiple input test
 
   beforeAll(async () => {
     try {
@@ -56,13 +71,19 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: 'invalidAddress', value: 10 }],
+        outputs: [{
+          address: 'invalidAddress',
+          value: 10
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -70,14 +91,23 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        inputs: [{ type: 'query', filter_address: 'invalidAddress' }],
-        outputs: [{ address: await wallet1.getAddressAt(5), value: 10 }],
+        inputs: [{
+          type: 'query',
+          filter_address: 'invalidAddress'
+        }],
+        outputs: [{
+          address: await wallet1.getAddressAt(5),
+          value: 10
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -85,15 +115,22 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
         change_address: 'invalidAddress',
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toContain('invalid');
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('invalid');
     done();
   });
 
@@ -105,15 +142,22 @@ describe('send tx (HTR)', () => {
           hash: 'invalidInput',
           index: 0
         }],
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
         change_address: 'invalidAddress',
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toContain('invalid');
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('invalid');
     done();
   });
 
@@ -128,15 +172,22 @@ describe('send tx (HTR)', () => {
             index: 0
           }
         ],
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
         change_address: 'invalidAddress',
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toContain('invalid');
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.error)
+      .toContain('invalid');
     done();
   });
 
@@ -144,16 +195,23 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
         change_address: wallet2.getAddressAt(1),
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(400);
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.success)
+      .toBe(false);
     const errorElement = response.body.error[0];
-    expect(errorElement.param).toBe('change_address');
-    expect(errorElement.msg).toContain('Invalid');
+    expect(errorElement.param)
+      .toBe('change_address');
+    expect(errorElement.msg)
+      .toContain('Invalid');
     done();
   });
 
@@ -161,15 +219,23 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 'incorrectValue' }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 'incorrectValue'
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(400);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
-    expect(response.body).toHaveProperty('error');
-    expect(response.body.error[0].msg).toContain('Invalid');
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body)
+      .toHaveProperty('error');
+    expect(response.body.error[0].msg)
+      .toContain('Invalid');
     done();
   });
 
@@ -177,12 +243,17 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 0 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 0
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(400);
-    expect(response.body.error[0].msg).toContain('Invalid');
+    expect(response.status)
+      .toBe(400);
+    expect(response.body.error[0].msg)
+      .toContain('Invalid');
     done();
   });
 
@@ -191,13 +262,19 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
       })
       .set({ 'x-wallet-id': wallet2.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -207,15 +284,24 @@ describe('send tx (HTR)', () => {
       .post('/wallet/send-tx')
       .send({
         outputs: [
-          { address: await wallet2.getAddressAt(1), value: 800 },
-          { address: await wallet2.getAddressAt(2), value: 800 },
+          {
+            address: await wallet2.getAddressAt(1),
+            value: 800
+          },
+          {
+            address: await wallet2.getAddressAt(2),
+            value: 800
+          },
         ],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -226,14 +312,20 @@ describe('send tx (HTR)', () => {
       .send({
         inputs: [fundTx2, fundTx3],
         outputs: [
-          { address: await wallet2.getAddressAt(1), value: 3000 },
+          {
+            address: await wallet2.getAddressAt(1),
+            value: 3000
+          },
         ],
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -242,14 +334,23 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
-        inputs: [{ type: 'query', filter_address: await wallet1.getAddressAt(5) }],
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        inputs: [{
+          type: 'query',
+          filter_address: await wallet1.getAddressAt(5)
+        }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 10
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -258,13 +359,19 @@ describe('send tx (HTR)', () => {
       .post('/wallet/send-tx')
       .send({
         inputs: [fundTx1],
-        outputs: [{ address: await wallet2.getAddressAt(0), value: 1001 }],
+        outputs: [{
+          address: await wallet2.getAddressAt(0),
+          value: 1001
+        }],
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.status).toBe(200);
-    expect(response.body.hash).toBeUndefined();
-    expect(response.body.success).toBe(false);
+    expect(response.status)
+      .toBe(200);
+    expect(response.body.hash)
+      .toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
     done();
   });
 
@@ -280,8 +387,10 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash).toBeDefined();
-    expect(tx.success).toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
+    expect(tx.success)
+      .toBe(true);
     done();
   });
 
@@ -320,8 +429,10 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash).toBeDefined();
-    expect(tx.success).toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
+    expect(tx.success)
+      .toBe(true);
     done();
   });
 
@@ -341,15 +452,19 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
 
     const [addr1, addr2] = await Promise.all([
       wallet2.getAddressInfo(1),
       wallet2.getAddressInfo(2),
     ]);
-    expect(addr1.total_amount_received).toBe(20);
-    expect(addr2.total_amount_received).toBe(30);
+    expect(addr1.total_amount_received)
+      .toBe(20);
+    expect(addr2.total_amount_received)
+      .toBe(30);
     done();
   });
 
@@ -370,13 +485,16 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.hash).toBeDefined();
+    expect(tx.hash)
+      .toBeDefined();
 
     const addr6 = await wallet2.getAddressInfo(6);
     const addr2 = await wallet3.getAddressInfo(2);
 
-    expect(addr6.total_amount_received).toBe(1500);
-    expect(addr2.total_amount_received).toBe(500);
+    expect(addr6.total_amount_received)
+      .toBe(1500);
+    expect(addr2.total_amount_received)
+      .toBe(500);
 
     tx5.hash = tx.hash;
     tx5.index = TestUtils.getOutputIndexFromTx(tx, 500);
@@ -401,15 +519,20 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
 
     const addr3 = await wallet2.getAddressInfo(3);
-    expect(addr3.total_amount_received).toBe(2000);
-    expect(addr3.total_amount_sent).toBe(2000);
+    expect(addr3.total_amount_received)
+      .toBe(2000);
+    expect(addr3.total_amount_sent)
+      .toBe(2000);
 
     const addr4 = await wallet1.getAddressInfo(4);
-    expect(addr4.total_amount_received).toBe(1100);
+    expect(addr4.total_amount_received)
+      .toBe(1100);
 
     done();
   });
@@ -426,11 +549,14 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
 
     const addr5 = await wallet2.getAddressInfo(5);
-    expect(addr5.total_amount_received).toBe(0);
+    expect(addr5.total_amount_received)
+      .toBe(0);
 
     done();
   });
@@ -455,14 +581,18 @@ describe('send tx (HTR)', () => {
       }
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
 
     const addr7 = await wallet2.getAddressInfo(10);
-    expect(addr7.total_amount_received).toBe(760);
+    expect(addr7.total_amount_received)
+      .toBe(760);
 
     const addr8 = await wallet2.getAddressInfo(11);
-    expect(addr8.total_amount_received).toBe(740);
+    expect(addr8.total_amount_received)
+      .toBe(740);
     done();
   });
 });
@@ -483,8 +613,14 @@ describe('send tx (custom tokens)', () => {
     uid: null
   };
 
-  const fundTx1 = { hash: null, index: null }; // Auto-input transactions
-  const fundTx2 = { hash: null, index: null }; // Token B transactions
+  const fundTx1 = {
+    hash: null,
+    index: null
+  }; // Auto-input transactions
+  const fundTx2 = {
+    hash: null,
+    index: null
+  }; // Token B transactions
   const tkaTx1 = { hash: null }; // Token A transaction to have two inputs
 
   beforeAll(async () => {
@@ -563,8 +699,10 @@ describe('send tx (custom tokens)', () => {
         }
       })
       .set({ 'x-wallet-id': wallet1.walletId });
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -585,8 +723,10 @@ describe('send tx (custom tokens)', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     // Currently ignoring the wrong name. To be fixed later
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -636,8 +776,10 @@ describe('send tx (custom tokens)', () => {
       .set({ 'x-wallet-id': wallet1.walletId });
 
     // Currently ignoring the wrong symbol. To be fixed later
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -653,8 +795,10 @@ describe('send tx (custom tokens)', () => {
         token: tokenA
       })
       .set({ 'x-wallet-id': wallet1.walletId });
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -705,8 +849,10 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -735,8 +881,10 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
@@ -765,17 +913,25 @@ describe('send tx (custom tokens)', () => {
       })
       .set({ 'x-wallet-id': wallet3.walletId });
 
-    expect(response.body.success).toBe(false);
-    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success)
+      .toBe(false);
+    expect(response.body.hash)
+      .toBeUndefined();
     done();
   });
 
   // Success transaction tests
 
-  const tkaTx2 = { hash: null, index: null }; // Change that will remain on wallet1
+  const tkaTx2 = {
+    hash: null,
+    index: null
+  }; // Change that will remain on wallet1
   it('should send a custom token with a single input', async done => {
     const sendOptions = {
-      inputs: [{ hash: tkaTx1.hash, index: 0 }], // Using index 0 of main transaction
+      inputs: [{
+        hash: tkaTx1.hash,
+        index: 0
+      }], // Using index 0 of main transaction
       outputs: [{
         address: await wallet2.getAddressAt(0),
         value: 200
@@ -787,8 +943,10 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
     tkaTx2.hash = tx.hash;
     tkaTx2.index = TestUtils.getOutputIndexFromTx(tx, 800);
 
@@ -800,7 +958,10 @@ describe('send tx (custom tokens)', () => {
   it('should send a custom token with multiple inputs', async done => {
     const sendOptions = {
       inputs: [
-        { hash: tkaTx1.hash, index: 1 }, // Using index 1 of main transaction
+        {
+          hash: tkaTx1.hash,
+          index: 1
+        }, // Using index 1 of main transaction
         tkaTx2 // Change on wallet 1
       ],
       outputs: [{
@@ -813,8 +974,10 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
 
     // All 2000 TKA are now on Wallet2
     done();
@@ -834,8 +997,10 @@ describe('send tx (custom tokens)', () => {
       fullObject: sendOptions
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
     done();
   });
 
@@ -875,9 +1040,18 @@ describe('send tx (custom tokens)', () => {
         }
       ],
       inputs: [
-        { hash: spreadTx.hash, index: 0 },
-        { hash: spreadTx.hash, index: 1 },
-        { hash: spreadTx.hash, index: 2 }
+        {
+          hash: spreadTx.hash,
+          index: 0
+        },
+        {
+          hash: spreadTx.hash,
+          index: 1
+        },
+        {
+          hash: spreadTx.hash,
+          index: 2
+        }
       ],
       token: tokenA
     };
@@ -885,8 +1059,10 @@ describe('send tx (custom tokens)', () => {
       fullObject: consolidateTxOptions
     });
 
-    expect(consolidateTx.success).toBe(true);
-    expect(consolidateTx.hash).toBeDefined();
+    expect(consolidateTx.success)
+      .toBe(true);
+    expect(consolidateTx.hash)
+      .toBeDefined();
     done();
   });
 
@@ -917,8 +1093,10 @@ describe('send tx (custom tokens)', () => {
       }
     });
 
-    expect(tx.success).toBe(true);
-    expect(tx.hash).toBeDefined();
+    expect(tx.success)
+      .toBe(true);
+    expect(tx.hash)
+      .toBeDefined();
     done();
   });
 });

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -4,6 +4,7 @@ import { WalletHelper } from './utils/wallet-helper';
 describe('send tx (HTR)', () => {
   let wallet1;
   let wallet2;
+  const fundTx1 = { hash: null, index: null };
 
   beforeAll(async () => {
     try {
@@ -11,7 +12,9 @@ describe('send tx (HTR)', () => {
       wallet2 = new WalletHelper('send-tx-2');
 
       await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
-      await wallet1.injectFunds(1000);
+      const fundTxObj = await wallet1.injectFunds(1000);
+      fundTx1.hash = fundTxObj.hash;
+      fundTx1.index = TestUtils.getOutputIndexFromTx(fundTxObj, 1000);
     } catch (err) {
       TestUtils.logError(err.stack);
     }
@@ -58,6 +61,26 @@ describe('send tx (HTR)', () => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        change_address: 'invalidAddress',
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
+    done();
+  });
+
+  it('should reject an invalid input', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        inputs: [{
+          hash: 'invalidInput',
+          index: 0
+        }],
         outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
         change_address: 'invalidAddress',
       })
@@ -165,7 +188,22 @@ describe('send tx (HTR)', () => {
     done();
   });
 
-  // Testing success cases, which have side-effects
+  it('should reject for insuficcient funds on input', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        inputs: [fundTx1],
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 1001 }],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    done();
+  });
+
+  // Lastly, testing success cases, which have side-effects
 
   it('should send with only the output address and value', async done => {
     const response = await TestUtils.request
@@ -237,15 +275,41 @@ describe('send tx (HTR)', () => {
     expect(addr2.total_amount_received).toBe(30);
     done();
   });
+
+  it('should send with correct input', async done => {
+    // Injecting 2000 HTR on wallet2, to ensure the funds would not be available otherwise
+    const fundTxObj = await wallet2.injectFunds(2000, 3);
+    const fundTx2 = {
+      hash: fundTxObj.hash,
+      index: TestUtils.getOutputIndexFromTx(fundTxObj, 2000)
+    };
+
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        inputs: [fundTx2],
+        outputs: [{ address: await wallet1.getAddressAt(4), value: 1100 }],
+      })
+      .set({ 'x-wallet-id': wallet2.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeDefined();
+    expect(response.body.success).toBe(true);
+
+    const addr3 = await wallet2.getAddressInfo(3);
+    expect(addr3.total_amount_received).toBe(2000);
+    expect(addr3.total_amount_sent).toBe(2000);
+
+    const addr4 = await wallet1.getAddressInfo(4);
+    expect(addr4.total_amount_received).toBe(1100);
+
+    done();
+  });
 });
 
 /*
 Change address with zero change
 Validation of the change address
-
-Send transaction with a single input - invalid source
-Send transaction with a single input - source without balance
-Send transaction with a single input - success
 
 Send a transaction with two inputs - one invalid source
 Send a transaction with two inputs - sources without combined balance

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -1,0 +1,209 @@
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('send tx (HTR)', () => {
+  let wallet1;
+  let wallet2;
+
+  beforeAll(async () => {
+    try {
+      wallet1 = new WalletHelper('send-tx-1');
+      wallet2 = new WalletHelper('send-tx-2');
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
+      await wallet1.injectFunds(1000);
+    } catch (err) {
+      TestUtils.logError(err.stack);
+    }
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+    await wallet2.stop();
+  });
+
+  // Starting with all the rejection tests, that do not have side-effects
+
+  it('should reject an invalid address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: 'invalidAddress', value: 10 }],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    done();
+  });
+
+  it('should reject an invalid change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        change_address: 'invalidAddress',
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
+    done();
+  });
+
+  it('should reject a change address that does not belong to the wallet', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        change_address: wallet2.getAddressAt(1),
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    const errorElement = response.body.error[0];
+    expect(errorElement.param).toBe('change_address');
+    expect(errorElement.msg).toContain('Invalid');
+    done();
+  });
+
+  it('should reject an invalid value', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 'incorrectValue' }],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    expect(response.body).toHaveProperty('error');
+    expect(response.body.error[0].msg).toContain('Invalid');
+    done();
+  });
+
+  it('should reject zero value', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 0 }],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error[0].msg).toContain('Invalid');
+    done();
+  });
+
+  it('should reject for insuficcient funds', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+      })
+      .set({ 'x-wallet-id': wallet2.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    done();
+  });
+
+  it('should reject for insufficient funds with two outputs', async done => {
+    // Both outputs are below the 1000 HTR available
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [
+          { address: await wallet2.getAddressAt(1), value: 800 },
+          { address: await wallet2.getAddressAt(2), value: 800 },
+        ],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false);
+    done();
+  });
+
+  // Testing success cases, which have side-effects
+
+  it('should send with only the output address and value', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeDefined();
+    expect(response.body.success).toBe(true);
+    done();
+  });
+
+  it('should send with only the output address and value and change', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ address: await wallet2.getAddressAt(0), value: 10 }],
+        change_address: await wallet1.getAddressAt(0)
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeDefined();
+    expect(response.body.success).toBe(true);
+    done();
+  });
+
+  it('should send with two outputs', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [
+          { address: await wallet2.getAddressAt(1), value: 20 },
+          { address: await wallet2.getAddressAt(2), value: 30 },
+        ],
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.hash).toBeDefined();
+
+    const [addr1, addr2] = await Promise.all([
+      wallet2.getAddressInfo(1),
+      wallet2.getAddressInfo(2),
+    ]);
+    expect(addr1.total_amount_received).toBe(20);
+    expect(addr2.total_amount_received).toBe(30);
+    done();
+  });
+});
+
+/*
+Valid and invalid values
+Valid and invalid destination address
+Sufficient and insufficient balance
+With and without change address
+Validation of the change address
+
+Send a transaction with a single token ( use the "token" attribute on body )
+Send a transaction with a single token ( use the "token" attribute on "outputs[n]" )
+Send a transaction with multiple tokens
+On each scenario test suite, include the following tests:
+
+Send a transaction with multiple inputs
+Send a transaction with multiple outputs
+Send a transaction with multiple inputs and outputs
+
+Also, make a separate test passing an object {type: "query", filterAddress: sample_address}
+on the inputs array to filter for UTXO's on the specified address.
+ */

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -271,7 +271,7 @@ describe('send tx (HTR)', () => {
   });
 
   it('should reject for insufficient funds with two inputs', async done => {
-    // Both outputs are below the 1000 HTR available
+    // Both inputs are have only 2000 HTR
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -563,7 +563,7 @@ describe('send tx (custom tokens)', () => {
 
     // Funds for single input/output tests - 1000 HTR + 2000 custom A
     await wallet1.injectFunds(1020, 0, { doNotWait: true });
-    // Funds for multiple token tests - 1000 HTR + 1000 custom B
+    // Funds for multiple token tests - 990 HTR + 1000 custom B
     await wallet3.injectFunds(1000, 0, { doNotWait: true });
     const tokenCreationA = await wallet1.createToken({
       name: tokenA.name,
@@ -773,7 +773,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a multi-input, multi token transaction with insuficcient funds (1)', async done => {
+  it('should reject a multi-input, multi token transaction with insuficcient funds (custom)', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({
@@ -803,7 +803,7 @@ describe('send tx (custom tokens)', () => {
     done();
   });
 
-  it('should reject a multi-input, multi token transaction with insuficcient funds (2)', async done => {
+  it('should reject a multi-input, multi token transaction with insuficcient funds (htr)', async done => {
     const response = await TestUtils.request
       .post('/wallet/send-tx')
       .send({

--- a/__tests__/integration/simple-send-tx.test.js
+++ b/__tests__/integration/simple-send-tx.test.js
@@ -2,8 +2,8 @@ import { TestUtils } from './utils/test-utils-integration';
 import { WalletHelper } from './utils/wallet-helper';
 
 describe('simple-send-tx (HTR)', () => {
-  let wallet1; let
-    wallet2;
+  let wallet1;
+  let wallet2;
 
   beforeAll(async () => {
     try {
@@ -139,8 +139,8 @@ describe('simple-send-tx (HTR)', () => {
 });
 
 describe('simple-send-tx (custom token)', () => {
-  let wallet3; let
-    wallet4;
+  let wallet3;
+  let wallet4;
   const tokenData = {
     name: 'SimpleTx Token',
     symbol: 'STX',

--- a/__tests__/integration/simple-send-tx.test.js
+++ b/__tests__/integration/simple-send-tx.test.js
@@ -53,7 +53,7 @@ describe('simple-send-tx (HTR)', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.success).toBe(false);
-    expect(response.text).toContain('value')
+    expect(response.text).toContain('value');
 
     done();
   });
@@ -106,7 +106,7 @@ describe('simple-send-tx (HTR)', () => {
     const transaction = response.body;
     expect(transaction.success).toBe(false);
     const errorElement = transaction.error[0];
-    expect(errorElement).toHaveProperty('param','change_address');
+    expect(errorElement).toHaveProperty('param', 'change_address');
     expect(errorElement.msg).toContain('Invalid');
 
     done();
@@ -174,7 +174,7 @@ describe('simple-send-tx (HTR)', () => {
     await TestUtils.pauseForWsUpdate();
 
     // The wallet1 started with 1000, transferred 400 to wallet2. Change should be 600
-    const addr5 = await wallet1.getAddressInfo(5)
+    const addr5 = await wallet1.getAddressInfo(5);
     expect(addr5.total_amount_received).toBe(600);
 
     const addr0 = await wallet2.getAddressInfo(0);
@@ -208,7 +208,6 @@ describe('simple-send-tx (custom token)', () => {
         doNotWait: true,
       });
       tokenData.uid = tokenResponse.hash;
-
     } catch (err) {
       TestUtils.logError(err.stack);
     }
@@ -250,7 +249,7 @@ describe('simple-send-tx (custom token)', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.success).toBe(false);
-    expect(response.text).toContain('value')
+    expect(response.text).toContain('value');
 
     done();
   });
@@ -344,7 +343,7 @@ describe('simple-send-tx (custom token)', () => {
     expect(addr0.total_amount_available).toBe(300);
 
     const balance3 = await wallet3.getBalance(tokenData.uid);
-    expect(balance3.available).toBe(700)
+    expect(balance3.available).toBe(700);
 
     done();
   });
@@ -374,7 +373,7 @@ describe('simple-send-tx (custom token)', () => {
     expect(addr5.total_amount_received).toBe(400);
 
     const addr0 = await wallet4.getAddressInfo(0, tokenData.uid);
-    expect(addr0.total_amount_available).toBe(600)
+    expect(addr0.total_amount_available).toBe(600);
 
     done();
   });

--- a/__tests__/integration/simple-send-tx.test.js
+++ b/__tests__/integration/simple-send-tx.test.js
@@ -1,0 +1,295 @@
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('simple-send-tx (HTR)', () => {
+  let wallet1; let
+    wallet2;
+
+  beforeAll(async () => {
+    try {
+      // Wallet with initial funds to send a transaction
+      wallet1 = new WalletHelper('simple-tx-1');
+      // Empty wallet to receive transactions and validate tests
+      wallet2 = new WalletHelper('simple-tx-2');
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
+      await wallet1.injectFunds(1000);
+    } catch (err) {
+      TestUtils.logError(err.stack);
+    }
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+    await wallet2.stop();
+  });
+
+  // Testing all transaction failures first, to have a easier starting test scenario
+
+  it('should not allow a transaction with an invalid value', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet2.getAddressAt(0),
+        value: 'invalidValue',
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    // It would be good to have a error message assertion
+
+    done();
+  });
+
+  it('should not allow a transaction with an invalid address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: 'invalidAddress',
+        value: 500,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Invalid');
+
+    done();
+  });
+
+  it('should not allow a transaction with an invalid change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet2.getAddressAt(0),
+        value: 500,
+        change_address: 'invalidChangeAddress',
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
+
+    done();
+  });
+
+  it('should not allow a transaction with insufficient balance', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet2.getAddressAt(0),
+        value: 2000,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Insufficient');
+
+    done();
+  });
+
+  // Executing all successful transactions
+
+  it('should make a successful transaction', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet2.getAddressAt(0),
+        value: 200,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.outputs).toHaveLength(2);
+
+    done();
+  });
+
+  it('should make a successful transaction with change address', async done => {
+    const changeAddress = await wallet1.getAddressAt(5);
+
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet2.getAddressAt(0),
+        value: 200,
+        change_address: changeAddress,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.outputs).toHaveLength(2);
+
+    // Check if the transaction arrived at the correct address
+
+    const addrInfoResponse = await TestUtils.request
+      .get('/wallet/address-info')
+      .query({ address: changeAddress })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    // The wallet1 started with 1000, transferred 400 to wallet2. Change should be 600
+    expect(addrInfoResponse?.body?.total_amount_received).toBe(600);
+    done();
+  });
+});
+
+describe('simple-send-tx (custom token)', () => {
+  let wallet3; let
+    wallet4;
+  const tokenData = {
+    name: 'SimpleTx Token',
+    symbol: 'STX',
+    uid: undefined,
+  };
+
+  beforeAll(async () => {
+    try {
+      // Wallet with initial 1000 Custom Token funds
+      wallet3 = new WalletHelper('simple-tx-3');
+      // Empty wallet to receive transactions and validate tests
+      wallet4 = new WalletHelper('simple-tx-4');
+
+      await WalletHelper.startMultipleWalletsForTest([wallet3, wallet4]);
+      await wallet3.injectFunds(10, undefined, { doNotWait: true });
+      const tokenResponse = await wallet3.createToken({
+        amount: 1000,
+        name: tokenData.name,
+        symbol: tokenData.symbol,
+        doNotWait: true,
+      });
+      tokenData.uid = tokenResponse.hash;
+
+      await TestUtils.delay(1000);
+    } catch (err) {
+      TestUtils.logError(err.stack);
+    }
+  });
+
+  afterAll(async () => {
+    await wallet3.stop();
+    await wallet4.stop();
+  });
+
+  // Testing all transaction failures first, to have a easier starting test scenario
+
+  it('should not allow a transaction with an invalid value', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet4.getAddressAt(0),
+        value: 'invalidValue',
+        token: tokenData.hash,
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    // It would be good to have a error message assertion
+
+    done();
+  });
+
+  it('should not allow a transaction with an invalid address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: 'invalidAddress',
+        value: 300,
+        token: tokenData.uid,
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Invalid');
+
+    done();
+  });
+
+  it('should not allow a transaction with an invalid change address', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet4.getAddressAt(0),
+        value: 300,
+        token: tokenData.uid,
+        change_address: 'invalidChangeAddress',
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('invalid');
+
+    done();
+  });
+
+  it('should not allow a transaction with insuficcient balance', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet4.getAddressAt(0),
+        value: 3000,
+        token: tokenData.uid,
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Insufficient');
+
+    done();
+  });
+
+  it('should should make a successful transaction', async done => {
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet4.getAddressAt(0),
+        value: 300,
+        token: tokenData.uid,
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.outputs).toHaveLength(2);
+
+    done();
+  });
+
+  it('should should make a successful transaction with change address', async done => {
+    const changeAddress = await wallet3.getAddressAt(5);
+
+    const response = await TestUtils.request
+      .post('/wallet/simple-send-tx')
+      .send({
+        address: await wallet4.getAddressAt(0),
+        value: 300,
+        token: tokenData.uid,
+        change_address: changeAddress
+      })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.outputs).toHaveLength(2);
+
+    // Check if the transaction arrived at the correct address
+
+    const addrInfoResponse = await TestUtils.request
+      .get('/wallet/address-info')
+      .query({ address: changeAddress, token: tokenData.uid })
+      .set({ 'x-wallet-id': wallet3.walletId });
+
+    // The wallet1 started with 1000, transferred 600 to wallet2. Change should be 400
+    expect(addrInfoResponse?.body?.total_amount_received).toBe(400);
+
+    done();
+  });
+});

--- a/__tests__/integration/simple-send-tx.test.js
+++ b/__tests__/integration/simple-send-tx.test.js
@@ -126,14 +126,12 @@ describe('simple-send-tx (HTR)', () => {
     expect(response.body.outputs).toHaveLength(2);
 
     // Check if the transaction arrived at the correct address
+    await TestUtils.pauseForWsUpdate();
 
-    const addrInfoResponse = await TestUtils.request
-      .get('/wallet/address-info')
-      .query({ address: changeAddress })
-      .set({ 'x-wallet-id': wallet1.walletId });
+    const addr5 = await wallet1.getAddressInfo(5)
 
     // The wallet1 started with 1000, transferred 400 to wallet2. Change should be 600
-    expect(addrInfoResponse?.body?.total_amount_received).toBe(600);
+    expect(addr5.total_amount_received).toBe(600);
     done();
   });
 });
@@ -155,7 +153,7 @@ describe('simple-send-tx (custom token)', () => {
       wallet4 = new WalletHelper('simple-tx-4');
 
       await WalletHelper.startMultipleWalletsForTest([wallet3, wallet4]);
-      await wallet3.injectFunds(10, undefined, { doNotWait: true });
+      await wallet3.injectFunds(10);
       const tokenResponse = await wallet3.createToken({
         amount: 1000,
         name: tokenData.name,
@@ -164,7 +162,6 @@ describe('simple-send-tx (custom token)', () => {
       });
       tokenData.uid = tokenResponse.hash;
 
-      await TestUtils.delay(1000);
     } catch (err) {
       TestUtils.logError(err.stack);
     }
@@ -281,14 +278,11 @@ describe('simple-send-tx (custom token)', () => {
     expect(response.body.outputs).toHaveLength(2);
 
     // Check if the transaction arrived at the correct address
-
-    const addrInfoResponse = await TestUtils.request
-      .get('/wallet/address-info')
-      .query({ address: changeAddress, token: tokenData.uid })
-      .set({ 'x-wallet-id': wallet3.walletId });
+    await TestUtils.pauseForWsUpdate();
+    const addr5 = await wallet3.getAddressInfo(5, tokenData.uid);
 
     // The wallet1 started with 1000, transferred 600 to wallet2. Change should be 400
-    expect(addrInfoResponse?.body?.total_amount_received).toBe(400);
+    expect(addr5.total_amount_received).toBe(400);
 
     done();
   });

--- a/__tests__/integration/simple-send-tx.test.js
+++ b/__tests__/integration/simple-send-tx.test.js
@@ -306,7 +306,7 @@ describe('simple-send-tx (custom token)', () => {
     done();
   });
 
-  it('should not allow a transaction with insuficcient balance', async done => {
+  it('should not allow a transaction with insufficient balance', async done => {
     const response = await TestUtils.request
       .post('/wallet/simple-send-tx')
       .send({

--- a/__tests__/integration/transaction.test.js
+++ b/__tests__/integration/transaction.test.js
@@ -8,7 +8,7 @@ describe('transaction routes', () => {
     try {
       // An empty wallet
       wallet1 = new WalletHelper('transaction-1');
-      await wallet1.start();
+      await WalletHelper.startMultipleWalletsForTest([wallet1]);
     } catch (err) {
       TestUtils.logError(err.stack);
     }

--- a/__tests__/integration/tx-history.test.js
+++ b/__tests__/integration/tx-history.test.js
@@ -30,12 +30,13 @@ describe('tx-history routes', () => {
       await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
 
       for (let amount = 10; amount < 60; amount += 10) {
-        const fundTx = await wallet2.injectFunds(amount, 1, { doNotWait: true });
+        const fundTx = await wallet2.injectFunds(amount, 1);
         fundTransactions[fundTx.hash] = fundTx;
         fundHashes[`tx${amount}`] = fundTx.hash;
       }
-      // Adding a single delay for all the above transactions to "settle" on the wallet's indexes
-      await TestUtils.delay(1000);
+
+      await TestUtils.pauseForWsUpdate();
+
     } catch (err) {
       TestUtils.logError(err.stack);
     }

--- a/__tests__/integration/tx-history.test.js
+++ b/__tests__/integration/tx-history.test.js
@@ -36,7 +36,6 @@ describe('tx-history routes', () => {
       }
 
       await TestUtils.pauseForWsUpdate();
-
     } catch (err) {
       TestUtils.logError(err.stack);
     }

--- a/__tests__/integration/tx-history.test.js
+++ b/__tests__/integration/tx-history.test.js
@@ -24,16 +24,18 @@ describe('tx-history routes', () => {
     try {
       // An empty wallet
       wallet1 = new WalletHelper('txHistory1');
-      await wallet1.start();
-
       // A wallet with 5 transactions containing 10, 20, 30, 40 and 50 HTR each
       wallet2 = new WalletHelper('txHistory2');
-      await wallet2.start();
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
+
       for (let amount = 10; amount < 60; amount += 10) {
-        const fundTx = await wallet2.injectFunds(amount, 1);
+        const fundTx = await wallet2.injectFunds(amount, 1, { doNotWait: true });
         fundTransactions[fundTx.hash] = fundTx;
         fundHashes[`tx${amount}`] = fundTx.hash;
       }
+      // Adding a single delay for all the above transactions to "settle" on the wallet's indexes
+      await TestUtils.delay(1000);
     } catch (err) {
       TestUtils.logError(err.stack);
     }

--- a/__tests__/integration/txLogger.js
+++ b/__tests__/integration/txLogger.js
@@ -82,7 +82,7 @@ export class TxLogger {
       ]
     });
 
-    this.#logger.info(`Log initialized`);
+    this.#logger.info('Log initialized');
   }
 
   /**
@@ -113,7 +113,7 @@ export class TxLogger {
    * @returns {void}
    */
   informWalletAddresses(walletId, addresses) {
-    this.#logger.info(`Sample of wallet addresses.`, { walletId, addresses });
+    this.#logger.info('Sample of wallet addresses.', { walletId, addresses });
   }
 
   /**

--- a/__tests__/integration/txLogger.js
+++ b/__tests__/integration/txLogger.js
@@ -109,7 +109,7 @@ export class TxLogger {
   /**
    * Wrapper for adding a "Wallet Addresses" message
    * @param {string} walletId
-   * @param {string} addresses
+   * @param {string[]} addresses
    * @returns {void}
    */
   informWalletAddresses(walletId, addresses) {

--- a/__tests__/integration/txLogger.js
+++ b/__tests__/integration/txLogger.js
@@ -26,10 +26,6 @@ export class TxLogger {
    */
   #logger;
 
-  get filename() {
-    return this.#instanceFilename;
-  }
-
   /**
    * Builds the log filename based on current time and an optional title.
    * The resulting filename will be in the format:
@@ -53,6 +49,10 @@ export class TxLogger {
     const additionalTitle = title ? `-${title}` : '';
     const filename = `${humanReadableTimestamp}${additionalTitle}-integrationTest.log`;
     this.#instanceFilename = filename;
+  }
+
+  get filename() {
+    return this.#instanceFilename;
   }
 
   /**

--- a/__tests__/integration/txLogger.js
+++ b/__tests__/integration/txLogger.js
@@ -68,15 +68,15 @@ export class TxLogger {
             winston.format.timestamp(),
             winston.format.colorize(),
           ),
-          level: config.consoleLevel || 'silly',
+          level: config.integrationTest.consoleLevel || 'silly',
         }),
         new winston.transports.File({
           format: winston.format.combine(
             winston.format.timestamp(),
             winston.format.prettyPrint()
           ),
-          filename: `${config.integrationTestLog.outputFolder}${this.#instanceFilename}`,
-          level: config.consoleLevel || 'silly',
+          filename: `${config.integrationTest.logOutputFolder}${this.#instanceFilename}`,
+          level: config.integrationTest.consoleLevel || 'silly',
           colorize: false,
         })
       ]

--- a/__tests__/integration/txLogger.js
+++ b/__tests__/integration/txLogger.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import winston from 'winston';
-import config from '../../src/config';
+import testConfig from './configuration/test.config';
 
 export const loggers = {
   /**
@@ -68,15 +68,15 @@ export class TxLogger {
             winston.format.timestamp(),
             winston.format.colorize(),
           ),
-          level: config.integrationTest.consoleLevel || 'silly',
+          level: testConfig.consoleLevel || 'silly',
         }),
         new winston.transports.File({
           format: winston.format.combine(
             winston.format.timestamp(),
             winston.format.prettyPrint()
           ),
-          filename: `${config.integrationTest.logOutputFolder}${this.#instanceFilename}`,
-          level: config.integrationTest.consoleLevel || 'silly',
+          filename: `${testConfig.logOutputFolder}${this.#instanceFilename}`,
+          level: testConfig.consoleLevel || 'silly',
           colorize: false,
         })
       ]

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -201,6 +201,21 @@ export class TestUtils {
   }
 
   /**
+   * Retrieves the Address Index on the Wallet
+   * @param {string} walletId Wallet identification
+   * @param {string} address Address to find the index
+   * @returns {Promise<number>}
+   */
+  static async getAddressIndex(walletId, address) {
+    const response = await TestUtils.request
+      .get('/wallet/address-index')
+      .query({ address })
+      .set(TestUtils.generateHeader(walletId));
+
+    return response.body.index;
+  }
+
+  /**
    * Retrieves address information based on the address index inside the wallet.
    * This is very close to the tests on `address-info.test.js` and as such should reflect any
    * changes that are made to the calls there.
@@ -373,6 +388,25 @@ export class TestUtils {
     const response = await TestUtils.request
       .get('/wallet/balance')
       .query(queryParams)
+      .set(TestUtils.generateHeader(walletId));
+
+    return response.body;
+  }
+
+  /**
+   * Returns a fully decoded transaction to allow for more complete data analysis.
+   * This is done through an HTTP request on the Wallet Headless, in behalf of a started wallet id.
+   *
+   * @param {string} txHash Transaction id
+   * @param {string} walletId Mandatory wallet id for requesting the Wallet Headless
+   * @returns {Promise<*>}
+   */
+  static async getDecodedTransaction(txHash, walletId) {
+    const response = await TestUtils.request
+      .get('/wallet/transaction')
+      .query({
+        id: txHash
+      })
       .set(TestUtils.generateHeader(walletId));
 
     return response.body;

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -143,7 +143,7 @@ export class TestUtils {
     // Wait until the wallet is actually started
     let status;
     while (!options.skipWait) {
-      const walletReady = await TestUtils.checkIfWalletIsReady(walletObj.walletId);
+      const walletReady = await TestUtils.isWalletReady(walletObj.walletId);
       if (walletReady) {
         status = true;
         break;
@@ -157,7 +157,13 @@ export class TestUtils {
     return { start, status };
   }
 
-  static async checkIfWalletIsReady(walletId) {
+  /**
+   * Makes a http request to check if the wallet is ready.
+   * Returns only the boolean result.
+   * @param {string} walletId Identification of the wallet
+   * @returns {Promise<boolean>} `true` if the wallet is ready
+   */
+  static async isWalletReady(walletId) {
     const res = await request
       .get('/wallet/status')
       .set(TestUtils.generateHeader(walletId));

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -4,7 +4,7 @@ import supertest from 'supertest';
 import { HathorWallet, wallet } from '@hathor/wallet-lib';
 import app from '../../../src';
 import { loggers } from '../txLogger';
-import config from '../../../src/config';
+import testConfig from '../configuration/test.config';
 
 const request = supertest(app);
 
@@ -82,7 +82,7 @@ export class TestUtils {
    * @returns {Promise<void>}
    */
   static async pauseForWsUpdate() {
-    await TestUtils.delay(config.integrationTest.wsUpdateDelay);
+    await TestUtils.delay(testConfig.wsUpdateDelay);
   }
 
   /**

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -146,12 +146,10 @@ export class TestUtils {
     const start = response.body;
 
     // Wait until the wallet is actually started
-    let status;
     if (options.waitForValidation) {
       while (true) {
         const walletReady = await TestUtils.isWalletReady(walletObj.walletId);
         if (walletReady) {
-          status = true;
           break;
         }
         await TestUtils.delay(500);
@@ -160,7 +158,7 @@ export class TestUtils {
     // Log the success and return
     loggers.test.informNewWallet(walletObj.walletId, walletObj.words);
 
-    return { start, status };
+    return { start };
   }
 
   /**
@@ -202,8 +200,7 @@ export class TestUtils {
   }
 
   /**
-   * Get the next addresses on this wallet that do not have transactions.
-   * The amount of addresses is the current gap limit.
+   * Get the all addresses on this wallet, limited by the current gap limit.
    * @param {string} walletId
    * @returns {Promise<string[]>}
    */
@@ -255,7 +252,7 @@ export class TestUtils {
   }
 
   /**
-   * Retrieves the index containing the desired output value.
+   * Searches the transaction outputs and retrieves the first index containing the desired value.
    * @example
    * // The txObject transaction contains many outputs, the second's value is 15
    * TestUtils.getOutputIndexFromTx(txObject, 15)
@@ -274,7 +271,7 @@ export class TestUtils {
       if (transaction.outputs[index].value !== value) {
         continue;
       }
-      return +index;
+      return parseInt(index);
     }
 
     return null;

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -126,7 +126,7 @@ export class TestUtils {
    * Starts a wallet. Prefer instantiating a WalletHelper instead.
    * @param {WalletData} walletObj
    * @param [options]
-   * @param {boolean} [options.waitForValidation] If true, will only return when wallet is ready
+   * @param {boolean} [options.waitWalletReady] If true, will only return when wallet is ready
    * @returns {Promise<{start:unknown,status:unknown}>}
    */
   static async startWallet(walletObj, options = {}) {
@@ -146,7 +146,7 @@ export class TestUtils {
     const start = response.body;
 
     // Wait until the wallet is actually started
-    if (options.waitForValidation) {
+    if (options.waitWalletReady) {
       while (true) {
         const walletReady = await TestUtils.isWalletReady(walletObj.walletId);
         if (walletReady) {
@@ -336,15 +336,15 @@ export class TestUtils {
    * A helper method for fetching the change output. Only useful when the transaction has exactly
    * two HTR outputs: one for the destination and one for the change address
    * @param {unknown} transaction Transaction as received in the response.body
-   * @param {number} txValue Tx value
+   * @param {number} destinationValue Value transferred to the destination
    * @returns {{
    * change: {index: number, value: number},
    * destination: {index: number, value: number}
    * }|null}
    */
-  static getOutputSummaryHtr(transaction, txValue) {
+  static getOutputSummaryHtr(transaction, destinationValue) {
     const returnValue = {
-      destination: { index: null, value: txValue },
+      destination: { index: null, value: destinationValue },
       change: { index: null, value: null }
     };
 
@@ -360,8 +360,8 @@ export class TestUtils {
         continue;
       }
 
-      // If the value is txValue, we assume this is the destination
-      if (output.value === txValue) {
+      // If the value is destinationValue, we assume this is the destination
+      if (output.value === destinationValue) {
         returnValue.destination.index = index;
         continue;
       }

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -121,7 +121,7 @@ export class TestUtils {
    * Starts a wallet. Prefer instantiating a WalletHelper instead.
    * @param {WalletData} walletObj
    * @param [options]
-   * @param {boolean} [options.skipWait] If true, skips the wallet status validation
+   * @param {boolean} [options.waitForValidation] If true, will only return when wallet is ready
    * @returns {Promise<{start:unknown,status:unknown}>}
    */
   static async startWallet(walletObj, options = {}) {
@@ -142,15 +142,16 @@ export class TestUtils {
 
     // Wait until the wallet is actually started
     let status;
-    while (!options.skipWait) {
-      const walletReady = await TestUtils.isWalletReady(walletObj.walletId);
-      if (walletReady) {
-        status = true;
-        break;
+    if (options.waitForValidation) {
+      while (true) {
+        const walletReady = await TestUtils.isWalletReady(walletObj.walletId);
+        if (walletReady) {
+          status = true;
+          break;
+        }
+        await TestUtils.delay(500);
       }
-      await TestUtils.delay(500);
     }
-
     // Log the success and return
     loggers.test.informNewWallet(walletObj.walletId, walletObj.words);
 

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -185,9 +185,10 @@ export class TestUtils {
   }
 
   /**
-   * Gets the address from a walletId and an index, using the Wallet Headless endpoint
-   * @param {string} walletId
-   * @param {number} index
+   * Gets the address from a walletId and an index, using the Wallet Headless endpoint.
+   * If no index is informed, the next address without transactions will be returned
+   * @param {string} walletId Walled identification
+   * @param {number} [index]
    * @returns {Promise<string>}
    */
   static async getAddressAt(walletId, index) {
@@ -197,6 +198,45 @@ export class TestUtils {
       .set(TestUtils.generateHeader(walletId));
 
     return response.body.address;
+  }
+
+  /**
+   * Retrieves address information based on the address index inside the wallet.
+   * This is very close to the tests on `address-info.test.js` and as such should reflect any
+   * changes that are made to the calls there.
+   * @param {string} address Address hash
+   * @param {string} walletId Wallet identification
+   * @param {string} [token] Token hash, defaults to HTR
+   * @returns {Promise<{
+   * token: (string), index: (number),
+   * total_amount_received: (number), total_amount_sent: (number),
+   * total_amount_locked: (number), total_amount_available: (number)
+   * }>}
+   */
+  static async getAddressInfo(address, walletId , token) {
+    const response = await TestUtils.request
+      .get('/wallet/address-info')
+      .query({
+        address: address,
+        token
+      })
+      .set(TestUtils.generateHeader(walletId));
+
+    // An error happened
+    if (response.status !== 200 || response.body.success !== true) {
+      throw new Error(`Failure on /wallet/address-info: ${response.text}`);
+    }
+
+    // Returning explicitly each property to help with code completion / test writing
+    const addrInfo = response.body;
+    return {
+      token: addrInfo.token,
+      index: addrInfo.index,
+      total_amount_received: addrInfo.total_amount_received,
+      total_amount_sent: addrInfo.total_amount_sent,
+      total_amount_available: addrInfo.total_amount_available,
+      total_amount_locked: addrInfo.total_amount_locked,
+    };
   }
 
   /**

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -295,7 +295,7 @@ export class TestUtils {
 
     // Logs the results
     await loggers.test.informSimpleTransaction({
-      title: `Injecting funds`,
+      title: 'Injecting funds',
       originWallet: WALLET_CONSTANTS.genesis.walletId,
       value,
       destinationAddress: address,

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -252,4 +252,26 @@ export class TestUtils {
 
     return transaction;
   }
+
+  /**
+   * Retrieves the index containing the desired output value.
+   * @example
+   * // The txObject transaction contains many outputs, the second's value is 15
+   * TestUtils.getOutputIndexFromTx(txObject, 15)
+   * // will return 1
+   *
+   * @param {unknown} transaction Transaction object, as returned in the `response.body`
+   * @param {number} value Value to search for
+   * @returns {number|null} Zero-based index containing the desired output
+   */
+  static getOutputIndexFromTx(transaction, value) {
+    if (!transaction?.outputs?.length) return null;
+
+    for (const index in transaction.outputs) {
+      if (transaction.outputs[index].value !== value) continue;
+      return +index;
+    }
+
+    return null;
+  }
 }

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import supertest from 'supertest';
-import { wallet, HathorWallet } from '@hathor/wallet-lib';
+import { HathorWallet, wallet } from '@hathor/wallet-lib';
 import app from '../../../src';
 import { loggers } from '../txLogger';
 
@@ -61,6 +61,14 @@ export function getRandomInt(max, min = 0) {
 
 export class TestUtils {
   /**
+   * Returns the Supertest `request` object for this application
+   * @returns {Test}
+   */
+  static get request() {
+    return request;
+  }
+
+  /**
    * Simple way to wait asynchronously before continuing the funcion. Does not block the JS thread.
    * @param {number} ms Amount of milliseconds to delay
    * @returns {Promise<unknown>}
@@ -69,14 +77,6 @@ export class TestUtils {
     return new Promise(resolve => {
       setTimeout(resolve, ms);
     });
-  }
-
-  /**
-   * Returns the Supertest `request` object for this application
-   * @returns {Test}
-   */
-  static get request() {
-    return request;
   }
 
   /**
@@ -92,7 +92,7 @@ export class TestUtils {
    *
    * @see TestUtils.stopWallet
    * @param {string} walletId
-   * @returns {{"x-wallet-id"}}
+   * @returns {{'x-wallet-id'}}
    */
   static generateHeader(walletId) {
     return { 'x-wallet-id': walletId };
@@ -206,7 +206,9 @@ export class TestUtils {
       .get('/wallet/addresses')
       .set(TestUtils.generateHeader(walletId));
 
-    if (!response.body.addresses) throw new Error(response.text);
+    if (!response.body.addresses) {
+      throw new Error(response.text);
+    }
     return response.body.addresses;
   }
 
@@ -271,10 +273,14 @@ export class TestUtils {
    * @returns {number|null} Zero-based index containing the desired output
    */
   static getOutputIndexFromTx(transaction, value) {
-    if (!transaction?.outputs?.length) return null;
+    if (!transaction?.outputs?.length) {
+      return null;
+    }
 
     for (const index in transaction.outputs) {
-      if (transaction.outputs[index].value !== value) continue;
+      if (transaction.outputs[index].value !== value) {
+        continue;
+      }
       return +index;
     }
 

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -81,7 +81,7 @@ export class TestUtils {
    * @returns {Promise<void>}
    */
   static async pauseForWsUpdate() {
-    await TestUtils.delay(1000)
+    await TestUtils.delay(1000);
   }
 
   /**
@@ -228,11 +228,11 @@ export class TestUtils {
    * total_amount_locked: (number), total_amount_available: (number)
    * }>}
    */
-  static async getAddressInfo(address, walletId , token) {
+  static async getAddressInfo(address, walletId, token) {
     const response = await TestUtils.request
       .get('/wallet/address-info')
       .query({
-        address: address,
+        address,
         token
       })
       .set(TestUtils.generateHeader(walletId));
@@ -326,7 +326,7 @@ export class TestUtils {
       if (transaction.outputs[index].value !== value) {
         continue;
       }
-      return parseInt(index);
+      return parseInt(index, 10);
     }
 
     return null;
@@ -337,16 +337,19 @@ export class TestUtils {
    * two HTR outputs: one for the destination and one for the change address
    * @param {unknown} transaction Transaction as received in the response.body
    * @param {number} txValue Tx value
-   * @returns {{change: {index: number, value: number}, destination: {index: number, value: number}}|null}
+   * @returns {{
+   * change: {index: number, value: number},
+   * destination: {index: number, value: number}
+   * }|null}
    */
   static getOutputSummaryHtr(transaction, txValue) {
     const returnValue = {
       destination: { index: null, value: txValue },
       change: { index: null, value: null }
-    }
+    };
 
     if (!transaction.outputs?.length) {
-      return null
+      return null;
     }
 
     for (const index in transaction.outputs) {
@@ -364,8 +367,8 @@ export class TestUtils {
       }
 
       // Any other value, we assume it's the change
-      returnValue.change.index = index
-      returnValue.change.value = output.value
+      returnValue.change.index = index;
+      returnValue.change.value = output.value;
     }
 
     return returnValue;
@@ -382,7 +385,7 @@ export class TestUtils {
   static async getBalance(walletId, tokenUid) {
     const queryParams = {};
     if (tokenUid) {
-      queryParams.token = tokenUid
+      queryParams.token = tokenUid;
     }
 
     const response = await TestUtils.request

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -4,6 +4,7 @@ import supertest from 'supertest';
 import { HathorWallet, wallet } from '@hathor/wallet-lib';
 import app from '../../../src';
 import { loggers } from '../txLogger';
+import config from '../../../src/config';
 
 const request = supertest(app);
 
@@ -81,7 +82,7 @@ export class TestUtils {
    * @returns {Promise<void>}
    */
   static async pauseForWsUpdate() {
-    await TestUtils.delay(1000);
+    await TestUtils.delay(config.integrationTest.wsUpdateDelay);
   }
 
   /**

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -276,4 +276,26 @@ export class TestUtils {
 
     return null;
   }
+
+  static async getTxHistory(walletId) {
+    const response = await TestUtils.request
+      .get('/wallet/tx-history')
+      .set(TestUtils.generateHeader(walletId));
+
+    return response.body;
+  }
+
+  static async getBalance(walletId, tokenUid) {
+    const queryParams = {};
+    if (tokenUid) {
+      queryParams.token = tokenUid
+    }
+
+    const response = await TestUtils.request
+      .get('/wallet/balance')
+      .query(queryParams)
+      .set(TestUtils.generateHeader(walletId));
+
+    return response.body;
+  }
 }

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -190,6 +190,21 @@ export class TestUtils {
   }
 
   /**
+   * Get the next addresses on this wallet that do not have transactions.
+   * The amount of addresses is the current gap limit.
+   * @param {string} walletId
+   * @returns {Promise<string[]>}
+   */
+  static async getSomeAddresses(walletId) {
+    const response = await TestUtils.request
+      .get('/wallet/addresses')
+      .set(TestUtils.generateHeader(walletId));
+
+    if (!response.body.addresses) throw new Error(response.text);
+    return response.body.addresses;
+  }
+
+  /**
    * Transfers funds to a destination address.
    * By default, this method also waits for a second to let the indexes build before returning.
    * @param {string} address Destination address

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -317,6 +317,45 @@ export class TestUtils {
     return null;
   }
 
+  /**
+   * A helper method for fetching the change output. Only useful when the transaction has exactly
+   * two HTR outputs: one for the destination and one for the change address
+   * @param {unknown} transaction Transaction as received in the response.body
+   * @param {number} txValue Tx value
+   * @returns {{change: {index: number, value: number}, destination: {index: number, value: number}}|null}
+   */
+  static getOutputSummaryHtr(transaction, txValue) {
+    const returnValue = {
+      destination: { index: null, value: txValue },
+      change: { index: null, value: null }
+    }
+
+    if (!transaction.outputs?.length) {
+      return null
+    }
+
+    for (const index in transaction.outputs) {
+      const output = transaction.outputs[index];
+
+      // Skipping all that outputs not involving HTR
+      if (output.token_data !== 0) {
+        continue;
+      }
+
+      // If the value is txValue, we assume this is the destination
+      if (output.value === txValue) {
+        returnValue.destination.index = index;
+        continue;
+      }
+
+      // Any other value, we assume it's the change
+      returnValue.change.index = index
+      returnValue.change.value = output.value
+    }
+
+    return returnValue;
+  }
+
   static async getTxHistory(walletId) {
     const response = await TestUtils.request
       .get('/wallet/tx-history')

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -339,6 +339,7 @@ export class WalletHelper {
     if (!transaction.success) {
       const txError = new Error(transaction.message);
       txError.innerError = response;
+      txError.sendOptions = sendOptions;
       throw txError;
     }
 

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -105,7 +105,7 @@ export class WalletHelper {
 
     // If the genesis wallet is not instantiated, start it. It should be always available
     const { genesis } = WALLET_CONSTANTS;
-    const isGenesisStarted = await TestUtils.checkIfWalletIsReady(genesis.walletId);
+    const isGenesisStarted = await TestUtils.isWalletReady(genesis.walletId);
     if (!isGenesisStarted) walletsArr.unshift(new WalletHelper(genesis.walletId, genesis.words));
 
     // Requests the start of all the wallets in quick succession
@@ -129,7 +129,7 @@ export class WalletHelper {
 
       // Checking the status of each wallet
       for (const walletId of pendingWalletIds) {
-        const isReady = await TestUtils.checkIfWalletIsReady(walletId);
+        const isReady = await TestUtils.isWalletReady(walletId);
         if (!isReady) continue;
 
         // If the wallet is ready, we remove it from the status check loop

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -1,6 +1,6 @@
 import { loggers } from '../txLogger';
 import { TestUtils, WALLET_CONSTANTS } from './test-utils-integration';
-import config from '../../../src/config';
+import testConfig from '../configuration/test.config';
 
 /**
  * A helper for testing the wallet
@@ -96,7 +96,7 @@ export class WalletHelper {
 
     // Enters the loop checking each wallet for its status
     const timestampStart = Date.now().valueOf();
-    const timestampTimeout = timestampStart + config.integrationTest.walletStartTimeout;
+    const timestampTimeout = timestampStart + testConfig.walletStartTimeout;
     while (true) {
       const pendingWalletIds = Object.keys(walletsPendingReady);
       // If all wallets were started, return to the caller.

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -132,7 +132,7 @@ export class WalletHelper {
         walletId: this.#walletId,
         words: this.#words,
       },
-      { waitForValidation: true }
+      { waitWalletReady: true }
     );
     this.#started = true;
 

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -181,9 +181,15 @@ export class WalletHelper {
   }
 
   /**
+   * Returns the next address without transactions for this wallet
+   * @returns {Promise<string>}
+   */
+  async getNextAddress() {
+    return TestUtils.getAddressAt(this.#walletId)
+  }
+
+  /**
    * Retrieves address information based on the address index inside the wallet.
-   * This is very close to the tests on `address-info.test.js` and as such should reflect any
-   * changes that are made to the calls there.
    * @param {number} index Address index
    * @param {string} [token] Token hash, defaults to HTR
    * @returns {Promise<{
@@ -193,29 +199,9 @@ export class WalletHelper {
    * }>}
    */
   async getAddressInfo(index, token) {
-    const response = await TestUtils.request
-      .get('/wallet/address-info')
-      .query({
-        address: await this.getAddressAt(index),
-        token
-      })
-      .set({ 'x-wallet-id': this.#walletId });
+    const address = await this.getAddressAt(index);
 
-    // An error happened
-    if (response.status !== 200 || response.body.success !== true) {
-      throw new Error(`Failure on /wallet/address-info: ${response.text}`);
-    }
-
-    // Returning explicitly each property to help with code completion / test writing
-    const addrInfo = response.body;
-    return {
-      token: addrInfo.token,
-      index: addrInfo.index,
-      total_amount_received: addrInfo.total_amount_received,
-      total_amount_sent: addrInfo.total_amount_sent,
-      total_amount_available: addrInfo.total_amount_available,
-      total_amount_locked: addrInfo.total_amount_locked,
-    };
+    return TestUtils.getAddressInfo(address, this.#walletId, token);
   }
 
   /**

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -132,7 +132,8 @@ export class WalletHelper {
         walletId: this.#walletId,
         words: this.#words,
       },
-      { waitForValidation: true });
+      { waitForValidation: true }
+    );
     this.#started = true;
 
     // Populating some addressess for this wallet
@@ -185,7 +186,7 @@ export class WalletHelper {
    * @returns {Promise<string>}
    */
   async getNextAddress() {
-    return TestUtils.getAddressAt(this.#walletId)
+    return TestUtils.getAddressAt(this.#walletId);
   }
 
   /**
@@ -358,10 +359,10 @@ export class WalletHelper {
   }
 
   async getTxHistory() {
-    return TestUtils.getTxHistory(this.#walletId)
+    return TestUtils.getTxHistory(this.#walletId);
   }
 
   async getBalance(tokenUid = null) {
-    return TestUtils.getBalance(this.#walletId, tokenUid)
+    return TestUtils.getBalance(this.#walletId, tokenUid);
   }
 }

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -82,13 +82,16 @@ export class WalletHelper {
     }
 
     // Requests the start of all the wallets in quick succession
+    const startPromisesArray = [];
     for (const wallet of walletsArr) {
-      await TestUtils.startWallet({
+      const promise = TestUtils.startWallet({
         walletId: wallet.walletId,
         words: wallet.words,
       });
       walletsPendingReady[wallet.walletId] = wallet;
+      startPromisesArray.push(promise);
     }
+    await Promise.all(startPromisesArray);
 
     // Enters the loop checking each wallet for its status
     while (true) {

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -34,7 +34,7 @@ export class WalletHelper {
    */
   constructor(walletId, words) {
     if (!walletId) {
-      throw new Error(`Wallet must have a walletId`);
+      throw new Error('Wallet must have a walletId');
     }
     this.#walletId = walletId;
 
@@ -353,7 +353,7 @@ export class WalletHelper {
     if (options.destinationWallet) {
       metadata.destinationWallet = options.destinationWallet;
     }
-    await loggers.test.insertLineToLog(`Transferring funds`, metadata);
+    await loggers.test.insertLineToLog('Transferring funds', metadata);
 
     return transaction;
   }

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -166,6 +166,44 @@ export class WalletHelper {
   }
 
   /**
+   * Retrieves address information based on the address index inside the wallet.
+   * This is very close to the tests on `address-info.test.js` and as such should reflect any
+   * changes that are made to the calls there.
+   * @param {number} index Address index
+   * @param {string} [token] Token hash, defaults to HTR
+   * @returns {Promise<{
+   * token: (string), index: (number),
+   * total_amount_received: (number), total_amount_sent: (number),
+   * total_amount_locked: (number), total_amount_available: (number)
+   * }>}
+   */
+  async getAddressInfo(index, token) {
+    const response = await TestUtils.request
+      .get('/wallet/address-info')
+      .query({
+        address: await this.getAddressAt(index),
+        token
+      })
+      .set({ 'x-wallet-id': this.#walletId });
+
+    // An error happened
+    if (response.status !== 200 || response.body.success !== true) {
+      throw new Error(`Failure on /wallet/address-info: ${response.text}`);
+    }
+
+    // Returning explicitly each property to help with code completion / test writing
+    const addrInfo = response.body;
+    return {
+      token: addrInfo.token,
+      index: addrInfo.index,
+      total_amount_received: addrInfo.total_amount_received,
+      total_amount_sent: addrInfo.total_amount_sent,
+      total_amount_available: addrInfo.total_amount_available,
+      total_amount_locked: addrInfo.total_amount_locked,
+    };
+  }
+
+  /**
    * Retrieves funds from the Genesis wallet and injects into this wallet at a specified address.
    * @param {number} value Value to be transferred
    * @param {number} [addressIndex=0] Address index. Defaults to 0

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -218,15 +218,14 @@ export class WalletHelper {
    * Retrieves funds from the Genesis wallet and injects into this wallet at a specified address.
    * @param {number} value Value to be transferred
    * @param {number} [addressIndex=0] Address index. Defaults to 0
-   * @param {FundInjectionOptions} [options]
    * @returns {Promise<{success}|*>}
    */
-  async injectFunds(value, addressIndex = 0, options = {}) {
+  async injectFunds(value, addressIndex = 0) {
     if (!this.#started) {
       throw new Error(`Cannot inject funds: wallet ${this.#walletId} is not started.`);
     }
     const destinationAddress = await this.getAddressAt(addressIndex);
-    return TestUtils.injectFundsIntoAddress(destinationAddress, value, this.#walletId, options);
+    return TestUtils.injectFundsIntoAddress(destinationAddress, value, this.#walletId);
   }
 
   /**
@@ -237,7 +236,6 @@ export class WalletHelper {
    * @param {string} params.symbol Token symbol
    * @param {string} [params.address] Destination address for the custom token
    * @param {string} [params.change_address] Destination address for the HTR change
-   * @param {boolean} [params.doNotWait] Skip waiting after the transaction
    * @returns {Promise<unknown>} Token creation transaction
    */
   async createToken(params) {
@@ -275,10 +273,6 @@ export class WalletHelper {
       throw injectError;
     }
 
-    // Returning the Create Token transaction
-    if (!params.doNotWait) {
-      await TestUtils.delay(1000);
-    }
     return transaction;
   }
 
@@ -301,7 +295,6 @@ export class WalletHelper {
    * @param {string} [options.token] Simpler way to inform transfer token instead of "outputs"
    * @param {string} [options.destinationWallet] Optional parameter to explain the funds destination
    * @param {string} [options.change_address] Optional parameter to set the change address
-   * @param {boolean} [options.doNotWait] If true, the response will be returned immediately
    * @returns {Promise<unknown>} Returns the transaction
    */
   async sendTx(options) {
@@ -348,18 +341,6 @@ export class WalletHelper {
       metadata.destinationWallet = options.destinationWallet;
     }
     await loggers.test.insertLineToLog(`Transferring funds`, metadata);
-
-    /*
-     * The balance in the storage is updated after the wallet receives a message via websocket
-     * from the full node. A simple wait is built here to allow for this message before continuing.
-     *
-     * In case there is a need to do multliple transactions before any assertion is executed,
-     * please use the `doNotWait` option and explicitly insert the delay only once.
-     * This will improve the test speed.
-     */
-    if (!options.doNotWait) {
-      await TestUtils.delay(1000);
-    }
 
     return transaction;
   }

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -329,7 +329,7 @@ export class WalletHelper {
     // Logs the results
     const metadata = {
       originWallet: this.#walletId,
-      id: transaction.hash,
+      hash: transaction.hash,
       ...sendOptions
     };
     if (options.destinationWallet) metadata.destinationWallet = options.destinationWallet;

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -82,8 +82,6 @@ export class WalletHelper {
       await TestUtils.startWallet({
         walletId: wallet.walletId,
         words: wallet.words,
-      }, {
-        skipWait: true
       });
       walletsPendingStart[wallet.walletId] = wallet;
     }
@@ -125,10 +123,12 @@ export class WalletHelper {
    * @returns {Promise<WalletData>}
    */
   async start(options = {}) {
-    await TestUtils.startWallet({
-      walletId: this.#walletId,
-      words: this.#words,
-    });
+    await TestUtils.startWallet(
+      {
+        walletId: this.#walletId,
+        words: this.#words,
+      },
+      { waitForValidation: true });
     this.#started = true;
 
     // Populating some addressess for this wallet

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -1,4 +1,4 @@
-import { loggers } from '../txLogger';
+import { loggers, TxLogger } from '../txLogger';
 import { TestUtils, WALLET_CONSTANTS } from './test-utils-integration';
 
 /**
@@ -135,6 +135,9 @@ export class WalletHelper {
         // If the wallet is ready, we remove it from the status check loop
         walletsPendingStart[walletId].__setStarted();
         delete walletsPendingStart[walletId];
+
+        const addresses = await TestUtils.getSomeAddresses(walletId);
+        await loggers.test.informWalletAddresses(walletId, addresses);
       }
     }
   }

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -369,4 +369,12 @@ export class WalletHelper {
 
     return transaction;
   }
+
+  async getTxHistory() {
+    return TestUtils.getTxHistory(this.#walletId)
+  }
+
+  async getBalance(tokenUid = null) {
+    return TestUtils.getBalance(this.#walletId, tokenUid)
+  }
 }

--- a/config.js.template
+++ b/config.js.template
@@ -40,6 +40,13 @@ module.exports = {
   },
   */
 
+  // Integration test configs
+  integrationTest: {
+    logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
+    consoleLevel: 'silly',
+    wsUpdateDelay: 1000,
+  },
+
   // Optional config so you can set the token you want to use in this wallet
   // If this parameter is set you don't need to pass your token when getting balance or sending tokens
   tokenUid: '',

--- a/config.js.template
+++ b/config.js.template
@@ -40,14 +40,6 @@ module.exports = {
   },
   */
 
-  // Integration test configs
-  integrationTest: {
-    logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
-    consoleLevel: 'silly',
-    wsUpdateDelay: 1000,
-    walletStartTimeout: 60000,
-  },
-
   // Optional config so you can set the token you want to use in this wallet
   // If this parameter is set you don't need to pass your token when getting balance or sending tokens
   tokenUid: '',

--- a/config.js.template
+++ b/config.js.template
@@ -45,6 +45,7 @@ module.exports = {
     logOutputFolder: 'tmp/', // Should match .github/workflows/integration-test.yml -> upload-artifact
     consoleLevel: 'silly',
     wsUpdateDelay: 1000,
+    walletStartTimeout: 60000,
   },
 
   // Optional config so you can set the token you want to use in this wallet

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -1,11 +1,11 @@
 module.exports = {
   clearMocks: true,
-  coverageDirectory: "coverage-integration",
-  testEnvironment: "node",
+  coverageDirectory: 'coverage-integration',
+  testEnvironment: 'node',
   collectCoverage: true,
-  collectCoverageFrom: ["<rootDir>/src/**/*.js"],
-  testMatch: ["<rootDir>/__tests__/integration/**/*.test.js"],
-  coverageReporters: ["text-summary", "lcov", "clover"],
+  collectCoverageFrom: ['<rootDir>/src/**/*.js'],
+  testMatch: ['<rootDir>/__tests__/integration/**/*.test.js'],
+  coverageReporters: ['text-summary', 'lcov', 'clover'],
   testTimeout: 20 * 60 * 1000, // 20 minutes seems reasonable for slow integration tests. May be adjusted with optimizations
-  setupFilesAfterEnv: ["<rootDir>/setupTests-integration.js"],
+  setupFilesAfterEnv: ['<rootDir>/setupTests-integration.js'],
 };

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -1,5 +1,4 @@
 import * as Path from 'path';
-import { TestUtils, WALLET_CONSTANTS } from './__tests__/integration/utils/test-utils-integration';
 import { loggers, TxLogger } from './__tests__/integration/txLogger';
 
 /**

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -21,7 +21,3 @@ beforeAll(async () => {
   testLogger.init();
   loggers.test = testLogger;
 });
-
-// This function will run after each test file is executed
-afterAll(async () => {
-});

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -21,11 +21,8 @@ beforeAll(async () => {
   const testLogger = new TxLogger(testName);
   testLogger.init();
   loggers.test = testLogger;
-
-  await TestUtils.startWallet(WALLET_CONSTANTS.genesis);
 });
 
 // This function will run after each test file is executed
 afterAll(async () => {
-  await TestUtils.stopWallet(WALLET_CONSTANTS.genesis.walletId);
 });


### PR DESCRIPTION
This pull request is the second phase of the implementation of Integration Tests on the Hathow Wallet Headless, and expands the scope of #149 .

#### Changes on previous tests:
- The wallets are now instantiated all at once on the `WalletHelper.startMultipleWalletsForTest()` method. This is a performance improvement, since wallet initialization is the most time-consuming process on the integration tests.
- Genesis wallet initialization was removed from the `setupTests-integration.js:beforeAll()` method to use the process above.

An effort was made to make the tests use as little transactions as possible, since transactions are the second slowest process on the tests. As the integration tests use Jest's `--runInBand` configuration, it became possible to use one test's resulting condition as precondition to the next tests.

Sometimes this may compromise the readability of the testing code, but it was a tradeoff for performance.

### Acceptance Criteria
- Run the integration tests on the following routes:
  - `/wallet/simple-send`
  - `/wallet/send-tx`
  - `/wallet/create-tokens`
  - `/wallet/mint-tokens`
  - `/wallet/melt-tokens`

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
