### PR TITLE
Fix issue when user filters UTXOs by address query and custom tokens

### DIFF
--- a/__tests__/__fixtures__/http-fixtures.js
+++ b/__tests__/__fixtures__/http-fixtures.js
@@ -527,6 +527,48 @@ export default {
         height: 19,
         tokens: ["03"]
       },
+      {
+        tx_id:
+          "00991cd24536f402ef60d37df3031e0cff1d4e78cdbf6101e3cde4217a7c4cc3",
+        version: 0,
+        weight: 21,
+        timestamp: 1615256216,
+        is_voided: false,
+        inputs: [],
+        outputs: [
+          {
+            value: 10,
+            token_data: 1,
+            script: "dqkUsmE9zshkgB58piBD7ETUV0e/NgmIrA==",
+            decoded: {
+              type: "P2PKH",
+              address: "WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp",
+            },
+            token: "04",
+            spent_by: null,
+            selected_as_input: false,
+          },
+          {
+            value: 10,
+            token_data: 0,
+            script: "dqkUsmE9zshkgB58piBD7ETUV0e/NgmIrA==",
+            decoded: {
+              type: "P2PKH",
+              address: "WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp",
+            },
+            token: "00",
+            spent_by: null,
+            selected_as_input: false,
+          },
+        ],
+        parents: [
+          "000004e31d32f699cc4d4cda8a31037f2197f2e18b2192f4f9225bf0fbb3760c",
+          "00975897028ceb037307327c953f5e7ad4d3f42402d71bd3d11ecb63ac39f01a",
+          "00e161a6b0bee1781ea9300680913fb76fd0fac4acab527cd9626cc1514abdc9",
+        ],
+        height: 19,
+        tokens: ["04"]
+      },
     ],
   },
   "/v1a/push_tx": {

--- a/__tests__/address.test.js
+++ b/__tests__/address.test.js
@@ -1,5 +1,5 @@
-import { wallet as walletUtils } from "@hathor/wallet-lib";
-import TestUtils from "./test-utils";
+import { wallet as walletUtils } from '@hathor/wallet-lib';
+import TestUtils from './test-utils';
 
 describe("address api", () => {
   it("should return 200 with a valid body", async () => {
@@ -7,14 +7,14 @@ describe("address api", () => {
       .get("/wallet/address")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.address).toBe(TestUtils.addresses[1]);
+    expect(response.body.address).toBe(TestUtils.addresses[4]);
 
     // Should return the same address for a second call
     response = await TestUtils.request
       .get("/wallet/address")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.address).toBe(TestUtils.addresses[1]);
+    expect(response.body.address).toBe(TestUtils.addresses[4]);
   });
 
   it("should return 200 with a valid body for index = 0", async () => {
@@ -43,7 +43,9 @@ describe("address api", () => {
 
   it("should return a new address with mark_as_used until the gapLimit is reached", async () => {
     const gapLimit = walletUtils.getGapLimit();
-    for (let index = 1; index <= gapLimit; index++) {
+    const startingIndex = 4; // First unused address
+    const upperLimit = gapLimit + startingIndex - 1; // Last address within the gap limit
+    for (let index = startingIndex; index <= upperLimit; index++) {
       const response = await TestUtils.request
         .get("/wallet/address")
         .query({ mark_as_used: true })
@@ -57,6 +59,6 @@ describe("address api", () => {
       .get("/wallet/address")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.address).toBe(TestUtils.addresses[gapLimit]);
+    expect(response.body.address).toBe(TestUtils.addresses[upperLimit]);
   });
 });

--- a/__tests__/addresses.test.js
+++ b/__tests__/addresses.test.js
@@ -1,5 +1,5 @@
-import { wallet as walletUtils } from "@hathor/wallet-lib";
-import TestUtils from "./test-utils";
+import { wallet as walletUtils } from '@hathor/wallet-lib';
+import TestUtils from './test-utils';
 
 describe("addresses api", () => {
   it("should return 200 with a valid body", async () => {
@@ -8,7 +8,7 @@ describe("addresses api", () => {
       .get("/wallet/addresses")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.addresses.length).toBe(gapLimit + 1);
+    expect(response.body.addresses.length).toBe(gapLimit + 4);
     expect(response.body.addresses).toEqual(TestUtils.addresses);
   });
 
@@ -24,7 +24,7 @@ describe("addresses api", () => {
       .get("/wallet/addresses")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.addresses.length).toBe(gapLimit + 1);
+    expect(response.body.addresses.length).toBe(gapLimit + 4);
     expect(response.body.addresses.slice(0, TestUtils.addresses.length)).toEqual(TestUtils.addresses);
   });
 });

--- a/__tests__/balance.test.js
+++ b/__tests__/balance.test.js
@@ -1,4 +1,4 @@
-import TestUtils from "./test-utils";
+import TestUtils from './test-utils';
 
 describe("balance api", () => {
   it("should return 200 with a valid body", async () => {
@@ -6,7 +6,7 @@ describe("balance api", () => {
       .get("/wallet/balance")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.available).toBe(76799);
+    expect(response.body.available).toBe(76809);
     expect(response.body.locked).toBe(6400);
   });
 

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -1410,6 +1410,19 @@ describe('filter query + custom tokens', () => {
     done();
   });
 
+  it('should reject for unavailable funds on address', async done => {
+    // Address 0 on this same wallet has enough funds, but address 1 hasn't.
+    const txErr = await wallet1.sendTx({
+      inputs: [{ type: 'query', filter_address: await wallet1.getAddressAt(1) }],
+      outputs: [{ token: bugCoin.uid, address: await wallet1.getAddressAt(2), value: 100 }],
+    }).catch(err => err.innerError);
+
+    expect(txErr.status).toBe(200);
+    expect(txErr.body.success).toBe(false);
+    expect(txErr.body.error).toContain('No utxos');
+    done();
+  });
+
   it('should send the custom token with a query filter by address 0', async done => {
     // Sending all the tokens to facilitate address-info validation
     const tx = await wallet1.sendTx({

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -321,6 +321,7 @@ export class WalletHelper {
    * })
    * @see https://wallet-headless.docs.hathor.network/#/paths/~1wallet~1simple-send-tx/post
    * @param options
+   * @param {string} [options.title] Optional title describing the transaction's context
    * @param {unknown} [options.fullObject] Advanced usage: a full body to send to post on 'send-tx'
    * @param {SendTxInputParam[]} [options.inputs] Optional Inputs
    * @param {SendTxOutputParam[]} [options.outputs] Complete Outputs
@@ -372,6 +373,9 @@ export class WalletHelper {
       hash: transaction.hash,
       ...sendOptions
     };
+    if (options.title) {
+      metadata.title = options.title;
+    }
     if (options.destinationWallet) {
       metadata.destinationWallet = options.destinationWallet;
     }

--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -168,6 +168,24 @@ describe("send-tx api", () => {
     expect(response.body.success).toBeFalsy();
   });
 
+  it("should not accept a custom token transaction without funds to cover it (filter query)", async () => {
+    const response = await TestUtils.request
+      .post("/wallet/send-tx")
+      .send({
+        inputs: [{ type: "query", filter_address: "WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN" }],
+        outputs: [
+          { address: "WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc", value: 1 },
+          { address: "WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc", value: 1, token: "04" }
+        ],
+      })
+      .set({ "x-wallet-id": TestUtils.walletId });
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeUndefined();
+    expect(response.body.success).toBe(false)
+    expect(response.body.error).toContain('No utxos available')
+    expect(response.body.token).toBe("04")
+  });
+
   it("should not accept a custom token transaction without funds to cover it (token as string)", async () => {
     const response = await TestUtils.request
       .post("/wallet/send-tx")

--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -1,4 +1,4 @@
-import TestUtils from "./test-utils";
+import TestUtils from './test-utils';
 
 describe("send-tx api", () => {
   it("should return 200 with a valid body selecting inputs by query", async () => {
@@ -7,6 +7,22 @@ describe("send-tx api", () => {
       .send({
         inputs: [{ type: "query", filter_address: "WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN" }],
         outputs: [{ address: "WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc", value: 1 }],
+      })
+      .set({ "x-wallet-id": TestUtils.walletId });
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBeDefined();
+    expect(response.body.success).toBeTruthy();
+  });
+
+  it("should return 200 with selecting inputs by query with custom tokens", async () => {
+    const response = await TestUtils.request
+      .post("/wallet/send-tx")
+      .send({
+        inputs: [{ type: "query", filter_address: "WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp" }],
+        outputs: [
+          { address: "WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc", value: 10 },
+          { address: "WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc", value: 10, token: "04" }
+        ],
       })
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -1,11 +1,11 @@
-import supertest from "supertest";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
-import app from "../src/index";
-import config from "../src/config";
-import httpFixtures from "./__fixtures__/http-fixtures";
-import wsFixtures from "./__fixtures__/ws-fixtures";
-import { Server } from "mock-socket";
+import supertest from 'supertest';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import app from '../src/index';
+import config from '../src/config';
+import httpFixtures from './__fixtures__/http-fixtures';
+import wsFixtures from './__fixtures__/ws-fixtures';
+import { Server } from 'mock-socket';
 
 const WALLET_ID = "stub_wallet";
 const SEED_KEY = "stub_seed";
@@ -47,6 +47,9 @@ class TestUtils {
     "Weg6WEncAEJs5qDbGUxcLTR3iycM3hrt4C",
     "WSVarF73e6UVccGwb44FvTtqFWsHQmjKCt",
     "Wc5YHn861241iLY42mFT8z1dT1UdsNWkfs",
+    "WU6KGNPuaRG4VCKC1fsKDh4fRZGbkqxG8Y",
+    "WTTdWuDGGsu7X5yjfTzdxR1mQBZkjQfi3V",
+    "WaMaVdMh5Je7qPLjaiePX96uWMwX5hdPVi"
   ];
 
   static get request() {

--- a/__tests__/tx-history.test.js
+++ b/__tests__/tx-history.test.js
@@ -1,4 +1,4 @@
-import TestUtils from "./test-utils";
+import TestUtils from './test-utils';
 
 describe("tx-history api", () => {
   it("should return 200 with a valid body", async () => {
@@ -6,7 +6,7 @@ describe("tx-history api", () => {
       .get("/wallet/tx-history")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body).toHaveLength(15);
+    expect(response.body).toHaveLength(16);
   });
 
   it("should return limit (string or number) the transactions returned", async () => {

--- a/__tests__/utxo.test.js
+++ b/__tests__/utxo.test.js
@@ -1,4 +1,4 @@
-import TestUtils from "./test-utils";
+import TestUtils from './test-utils';
 
 describe("utxo api", () => {
   it("utxo-filter should return 200 with a valid body", async () => {
@@ -6,8 +6,8 @@ describe("utxo api", () => {
       .get("/wallet/utxo-filter")
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.utxos).toHaveLength(13);
-    expect(response.body.total_amount_available).toBe(76799);
+    expect(response.body.utxos).toHaveLength(14);
+    expect(response.body.total_amount_available).toBe(76809);
     expect(response.body.total_amount_locked).toBe(6400);
   });
 
@@ -19,8 +19,8 @@ describe("utxo api", () => {
       })
       .set({ "x-wallet-id": TestUtils.walletId });
     expect(response.status).toBe(200);
-    expect(response.body.total_utxos_consolidated).toBe(12);
-    expect(response.body.total_amount).toBe(76799);
-    expect(response.body.utxos).toHaveLength(12);
+    expect(response.body.total_utxos_consolidated).toBe(13);
+    expect(response.body.total_amount).toBe(76809);
+    expect(response.body.utxos).toHaveLength(13);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -736,20 +736,19 @@ walletRouter.post('/send-tx',
       const treatedInputs = []
 
       // We need to fetch UTXO's for each token on the "outputs"
-      const tokensList = Object.keys(tokens)
-      for (const tokenUid of tokensList) {
-        const tokenObj = tokens.get(tokenUid);
+      for (const element of tokens) {
+        const [tokenUid, tokenObj] = element
 
         const queryOptions = {
           ...inputs[0],
-          token: tokenObj.tokenUid
+          token: tokenUid
         }
         const utxos = getUtxosToFillTx(wallet, tokenObj.amount, queryOptions);
         if (!utxos) {
           const response = {
             success: false,
             error: 'No utxos available for the query filter for this amount.',
-            token: tokenObj.uid
+            token: tokenUid
           };
           res.send(response);
           lock.unlock(lockTypes.SEND_TX);

--- a/src/index.js
+++ b/src/index.js
@@ -733,14 +733,16 @@ walletRouter.post('/send-tx',
   if (inputs.length > 0) {
     // In case the first input is a query command, we will overwrite the inputs array with results
     if (inputs[0].type === 'query') {
-      const treatedInputs = []
+      // Overwriting the body parameter with the actual inputs
+      const query = inputs[0];
+      inputs = []
 
       // We need to fetch UTXO's for each token on the "outputs"
       for (const element of tokens) {
         const [tokenUid, tokenObj] = element
 
         const queryOptions = {
-          ...inputs[0],
+          ...query,
           token: tokenUid
         }
         const utxos = getUtxosToFillTx(wallet, tokenObj.amount, queryOptions);
@@ -756,11 +758,9 @@ walletRouter.post('/send-tx',
         }
 
         for (const utxo of utxos) {
-          treatedInputs.push({ txId: utxo.tx_id, index: utxo.index });
+          inputs.push({ txId: utxo.tx_id, index: utxo.index });
         }
       }
-      // Overwriting the body parameter with the actual inputs
-      inputs = treatedInputs
     } else {
       // The new lib version expects input to have tx_id and not hash
       inputs = inputs.map((input) => {

--- a/src/index.js
+++ b/src/index.js
@@ -699,9 +699,9 @@ walletRouter.post('/send-tx',
 
   /**
    * Map of tokens on the output that will be needed on the automatic input calculation
-   * @type {Record<string,TokenOutput>}
+   * @type {Map<string, TokenOutput>}
    */
-  const tokens = {}
+  const tokens = new Map();
 
   // I tried to use the default schema with express validator to set the default token as HTR
   // but apparently is not possible https://github.com/express-validator/express-validator/issues/682
@@ -715,10 +715,11 @@ walletRouter.post('/send-tx',
     }
 
     // Updating the `tokens` amount
-    if (!tokens[output.token]) {
-      tokens[output.token] = { tokenUid: output.token, amount: 0 }
+    if (!tokens.has(output.token)) {
+      tokens.set(output.token, { tokenUid: output.token, amount: 0 });
     }
-    tokens[output.token].amount += output.value
+    const sumObject = tokens.get(output.token);
+    sumObject.amount += output.value;
   }
 
   // Expects array of objects with {'hash', 'index'}
@@ -737,7 +738,7 @@ walletRouter.post('/send-tx',
       // We need to fetch UTXO's for each token on the "outputs"
       const tokensList = Object.keys(tokens)
       for (const tokenUid of tokensList) {
-        const tokenObj = tokens[tokenUid];
+        const tokenObj = tokens.get(tokenUid);
 
         const queryOptions = {
           ...inputs[0],

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,15 @@
 
 import express from 'express';
 import morgan from 'morgan';
-import { Connection, HathorWallet, wallet as oldWalletUtils, walletUtils, tokens, errors, constants as hathorLibConstants, config as hathorLibConfig } from '@hathor/wallet-lib';
+import {
+  config as hathorLibConfig,
+  Connection,
+  constants as hathorLibConstants,
+  errors,
+  HathorWallet,
+  wallet as oldWalletUtils,
+  walletUtils
+} from '@hathor/wallet-lib';
 import { body, checkSchema, matchedData, query, validationResult } from 'express-validator';
 
 import config from './config';
@@ -564,6 +572,13 @@ const getUtxosToFillTx = (wallet, sumOutputs, options) => {
 }
 
 /**
+ * @typedef TokenOutput
+ * A structure to help calculate how many tokens will be needed on send-tx's automatic inputs
+ * @property {string} tokenUid Hash identification of the token
+ * @property {number} amount Amount of tokens necessary on the inputs
+ */
+
+/**
  * POST request to send a transaction with many outputs and inputs selection
  * For the docs, see api-docs.js
  *
@@ -682,6 +697,12 @@ walletRouter.post('/send-tx',
   const wallet = req.wallet;
   const outputs = req.body.outputs;
 
+  /**
+   * Map of tokens on the output that will be needed on the automatic input calculation
+   * @type {Record<string,TokenOutput>}
+   */
+  const tokens = {}
+
   // I tried to use the default schema with express validator to set the default token as HTR
   // but apparently is not possible https://github.com/express-validator/express-validator/issues/682
   for (const output of outputs) {
@@ -692,6 +713,12 @@ walletRouter.post('/send-tx',
       const tokenObj = req.body.token || hathorLibConstants.HATHOR_TOKEN_CONFIG;
       output.token = tokenObj.uid;
     }
+
+    // Updating the `tokens` amount
+    if (!tokens[output.token]) {
+      tokens[output.token] = { tokenUid: output.token, amount: 0 }
+    }
+    tokens[output.token].amount += output.value
   }
 
   // Expects array of objects with {'hash', 'index'}
@@ -703,19 +730,37 @@ walletRouter.post('/send-tx',
   }
 
   if (inputs.length > 0) {
+    // In case the first input is a query command, we will overwrite the inputs array with results
     if (inputs[0].type === 'query') {
-      // First get sum of all outputs
-      const sumOutputs = outputs.reduce((acc, obj) => obj.value + acc, 0);
-      const utxos = getUtxosToFillTx(wallet, sumOutputs, inputs[0]);
-      if (!utxos) {
-        const response = {success: false, error: 'No utxos available for the query filter for this amount.'};
-        res.send(response);
-        lock.unlock(lockTypes.SEND_TX);
-        return;
+      const treatedInputs = []
+
+      // We need to fetch UTXO's for each token on the "outputs"
+      const tokensList = Object.keys(tokens)
+      for (const tokenUid of tokensList) {
+        const tokenObj = tokens[tokenUid];
+
+        const queryOptions = {
+          ...inputs[0],
+          token: tokenObj.tokenUid
+        }
+        const utxos = getUtxosToFillTx(wallet, tokenObj.amount, queryOptions);
+        if (!utxos) {
+          const response = {
+            success: false,
+            error: 'No utxos available for the query filter for this amount.',
+            token: tokenObj.uid
+          };
+          res.send(response);
+          lock.unlock(lockTypes.SEND_TX);
+          return;
+        }
+
+        for (const utxo of utxos) {
+          treatedInputs.push({ txId: utxo.tx_id, index: utxo.index });
+        }
       }
-      inputs = utxos.map((utxo) => {
-        return {txId: utxo.tx_id, index: utxo.index};
-      });
+      // Overwriting the body parameter with the actual inputs
+      inputs = treatedInputs
     } else {
       // The new lib version expects input to have tx_id and not hash
       inputs = inputs.map((input) => {

--- a/src/index.js
+++ b/src/index.js
@@ -572,13 +572,6 @@ const getUtxosToFillTx = (wallet, sumOutputs, options) => {
 }
 
 /**
- * @typedef TokenOutput
- * A structure to help calculate how many tokens will be needed on send-tx's automatic inputs
- * @property {string} tokenUid Hash identification of the token
- * @property {number} amount Amount of tokens necessary on the inputs
- */
-
-/**
  * POST request to send a transaction with many outputs and inputs selection
  * For the docs, see api-docs.js
  *
@@ -696,6 +689,13 @@ walletRouter.post('/send-tx',
 
   const wallet = req.wallet;
   const outputs = req.body.outputs;
+
+  /**
+   * @typedef TokenOutput
+   * A structure to help calculate how many tokens will be needed on send-tx's automatic inputs
+   * @property {string} tokenUid Hash identification of the token
+   * @property {number} amount Amount of tokens necessary on the inputs
+   */
 
   /**
    * Map of tokens on the output that will be needed on the automatic input calculation


### PR DESCRIPTION
The feature to `send-tx` querying by filter address was only working for HTR tokens, and would have wrong behaviors when any of the outputs had a custom token.

### Acceptance Criteria
- A transaction must be successful with input address filter query and custom tokens, as described in #151 

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
