### PR TITLE
Integration tests: utxo-filter, utxo-consolidation, create-nft

### DIFF
--- a/__tests__/integration/utxo-filter.test.js
+++ b/__tests__/integration/utxo-filter.test.js
@@ -1,0 +1,38 @@
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+describe('balance routes', () => {
+  /** @type WalletHelper */
+  let wallet1;
+
+  beforeAll(async () => {
+    try {
+      // First wallet, no balance
+      wallet1 = new WalletHelper('utxo-filter-1');
+
+      await WalletHelper.startMultipleWalletsForTest([wallet1]);
+
+      await TestUtils.pauseForWsUpdate();
+    } catch (err) {
+      TestUtils.logError(err.stack);
+    }
+  });
+
+  afterAll(async () => {
+    await wallet1.stop();
+  });
+
+  it('should return empty results for an empty wallet', async done => {
+    const utxoResponse = await TestUtils.request
+      .get('/wallet/utxo-filter')
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    const utxoResults = utxoResponse.body;
+    expect(utxoResults.total_amount_available).toBe(0);
+    expect(utxoResults.total_utxos_available).toBe(0);
+    expect(utxoResults.total_amount_locked).toBe(0);
+    expect(utxoResults.total_utxos_locked).toBe(0);
+    expect(utxoResults.utxos).toHaveProperty('length', 0);
+    done();
+  });
+});


### PR DESCRIPTION
This pull request is the third phase of the implementation of Integration Tests on the Hathor Wallet Headless, and expands the scope of #149 and #152.

### Acceptance Criteria
- Run the integration tests on the following routes:
  - `/wallet/utxo-filter`
  - `/wallet/utxo-consolidation`
  - `/wallet/create-nft`


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
