### PR TITLE
Fix Integration Tests not passing on GitHub CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,12 +4,14 @@ on:
     branches:
       - master
       - dev
+      - test/fix-integration-ci
     tags:
       - v*
     pull_request:
       branches:
         - dev
         - master
+        - test/fix-integration-ci
 jobs:
   itest:
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,14 +4,12 @@ on:
     branches:
       - master
       - dev
-      - test/fix-integration-ci
     tags:
       - v*
     pull_request:
       branches:
         - dev
         - master
-        - test/fix-integration-ci
 jobs:
   itest:
     runs-on: ubuntu-20.04

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -304,6 +304,8 @@ export class TestUtils {
       id: transaction.hash
     });
 
+    await TestUtils.pauseForWsUpdate();
+
     return transaction;
   }
 

--- a/__tests__/integration/utils/wallet-helper.js
+++ b/__tests__/integration/utils/wallet-helper.js
@@ -286,6 +286,8 @@ export class WalletHelper {
       throw injectError;
     }
 
+    await TestUtils.pauseForWsUpdate();
+
     return transaction;
   }
 
@@ -380,6 +382,8 @@ export class WalletHelper {
       metadata.destinationWallet = options.destinationWallet;
     }
     await loggers.test.insertLineToLog('Transferring funds', metadata);
+
+    await TestUtils.pauseForWsUpdate();
 
     return transaction;
   }


### PR DESCRIPTION
After an optimization of the integration TestUtils, [made on PR 152](https://github.com/HathorNetwork/hathor-wallet-headless/pull/152#discussion_r825530485), the tests became too fast for the `wallet-lib` cache to keep up via _websocket_. This made the CI test as a whole fail consistently.

This PR removes this optimization and adds again a short pause after every transaction sent to the blockchain, allowing the `lib` cache to be updated before continuing. The tests are being successful with this approach.

For a sample of success evidence, see cc35359 commit and its [CI workflow](https://github.com/HathorNetwork/hathor-wallet-headless/runs/5699349392?check_suite_focus=true).

### Acceptance Criteria
- The Integration Tests should pass on the GitHub CI


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
