### PR TITLE
fix: utxo-filter parameter only-available

### DIFF
--- a/__tests__/integration/utxo-filter.test.js
+++ b/__tests__/integration/utxo-filter.test.js
@@ -417,7 +417,7 @@ describe('utxo-filter routes', () => {
   });
 
   // It seems there is a name mismatch on the lib parameter: only_available => only_available_utxos
-  it.skip('should return correct results for only_available', async () => {
+  it('should return correct results for only_available', async () => {
     /*
      * The miner wallet always has some locked utxos because of the mining.
      * There is a small chance that between each request a new block reward has been delivered,
@@ -435,7 +435,7 @@ describe('utxo-filter routes', () => {
       .set({ 'x-wallet-id': minerWallet.walletId });
     const availableUtxosPromise = await TestUtils.request
       .get('/wallet/utxo-filter')
-      .query({ only_available: true })
+      .query({ only_available_utxos: true })
       .set({ 'x-wallet-id': minerWallet.walletId });
 
     const [utxosResponse, availableUtxosResponse] = await Promise.all([

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -332,7 +332,7 @@ walletRouter.get(
   query('amount_smaller_than').isInt().optional().toInt(),
   query('amount_bigger_than').isInt().optional().toInt(),
   query('maximum_amount').isInt().optional().toInt(),
-  query('only_available').isBoolean().optional().toBoolean(),
+  query('only_available_utxos').isBoolean().optional().toBoolean(),
   utxoFilter
 );
 


### PR DESCRIPTION
The parameter to filter by available utxos was incorrectly configured on the application routes.

It was renamed on the routes and on the integration test file. The docs were correct already.

### Acceptance Criteria
- The parameter to filter only available UTXO's should work according to [the docs](https://wallet-headless.docs.hathor.network/#/paths/~1wallet~1utxo-filter/get)


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
