### PR TITLE
feat: add length max for data script outputs

### DIFF
--- a/__tests__/__fixtures__/feature-fixture.js
+++ b/__tests__/__fixtures__/feature-fixture.js
@@ -1,5 +1,6 @@
 const constants = {
   MULTISIG_ENABLED: true,
+  MAX_DATA_SCRIPT_LENGTH: 150,
 };
 
 // Allow change config at runtime

--- a/__tests__/create-nft.test.js
+++ b/__tests__/create-nft.test.js
@@ -1,4 +1,5 @@
 import TestUtils from './test-utils';
+import { MAX_DATA_SCRIPT_LENGTH } from '../src/constants';
 
 describe('create-nft api', () => {
   it('should return 200 with a valid body', async () => {
@@ -73,5 +74,33 @@ describe('create-nft api', () => {
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
     expect(response2.body.success).toBeFalsy();
+  });
+
+  it('should not create an NFT with data size bigger than the max', async () => {
+    // Error with MAX + 1
+    const response = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        name: 'stub_token',
+        symbol: '03',
+        amount: 1,
+        data: 'a'.repeat(MAX_DATA_SCRIPT_LENGTH + 1),
+      })
+      .set({ 'x-wallet-id': TestUtils.walletId });
+    expect(response.status).toBe(400);
+
+    // Success with MAX
+    const response2 = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        name: 'stub_token',
+        symbol: '03',
+        amount: 1,
+        data: 'a'.repeat(MAX_DATA_SCRIPT_LENGTH),
+      })
+      .set({ 'x-wallet-id': TestUtils.walletId });
+    expect(response2.status).toBe(200);
+    expect(response2.body.success).toBeTruthy();
+    expect(response2.body.hash).toBeDefined();
   });
 });

--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -1,4 +1,5 @@
 import TestUtils from './test-utils';
+import { MAX_DATA_SCRIPT_LENGTH } from '../src/constants';
 
 describe('send-tx api', () => {
   it('should return 200 with a valid body selecting inputs by query', async () => {
@@ -285,5 +286,27 @@ describe('send-tx api', () => {
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeTruthy();
     expect(response.body.success).toBeTruthy();
+  });
+
+  it('should not accept a transaction with data size bigger than the maximum', async () => {
+    // Error with MAX + 1
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ type: 'data', data: 'a'.repeat(MAX_DATA_SCRIPT_LENGTH + 1) }],
+      })
+      .set({ 'x-wallet-id': TestUtils.walletId });
+    expect(response.status).toBe(400);
+
+    // Success with MAX
+    const response2 = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        outputs: [{ type: 'data', data: 'a'.repeat(MAX_DATA_SCRIPT_LENGTH) }],
+      })
+      .set({ 'x-wallet-id': TestUtils.walletId });
+    expect(response2.status).toBe(200);
+    expect(response2.body.hash).toBeTruthy();
+    expect(response2.body.success).toBeTruthy();
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,4 +25,7 @@ module.exports = {
    * Do NOT enable this unless you know what you're doing.
    */
   MULTISIG_ENABLED: false,
+
+  // Max length of data script outputs string
+  MAX_DATA_SCRIPT_LENGTH: 150,
 };

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -15,6 +15,7 @@ const {
   getAddressIndex
 } = require('../../controllers/wallet/wallet.controller');
 const txProposalRouter = require('./tx-proposal.routes');
+const { MAX_DATA_SCRIPT_LENGTH } = require('../../constants');
 
 const walletRouter = Router({ mergeParams: true });
 walletRouter.use(walletMiddleware);
@@ -217,6 +218,11 @@ walletRouter.post(
     'outputs.*.data': {
       in: ['body'],
       isString: true,
+      isLength: {
+        options: {
+          max: MAX_DATA_SCRIPT_LENGTH
+        }
+      },
       optional: true
     },
     'outputs.*': {
@@ -403,7 +409,7 @@ walletRouter.post(
   body('name').isString(),
   body('symbol').isString(),
   body('amount').isInt({ min: 1 }).toInt(),
-  body('data').isString(),
+  body('data').isString().isLength({ max: MAX_DATA_SCRIPT_LENGTH }),
   body('address').isString().optional(),
   body('change_address').isString().optional(),
   body('create_mint').isBoolean().optional().toBoolean(),


### PR DESCRIPTION
### Acceptance Criteria
- APIs that create data script outputs should have maximum length of data string. For now, we have only send-tx and create-nft.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
