### PR TITLE
fix: using module.exports instead of export default

### DIFF
--- a/config.js.docker
+++ b/config.js.docker
@@ -112,4 +112,4 @@ if (debugPath) {
   };
 }
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
### Summary

The wallet was not working when using docker because we are importing the config with `require` and the config is being exported with `export default config;`.

At first I was doing the solution to refactor all `require` to use `import`, so we wouldn't need to care about it. After I changed in all internal modules this import (controllers, middlewares, routes, ...), I got an error that we can't have `import` in modules that have `module.exports`. Given that we need this fix and the refactor would need to be bigger, I decided to go back to the `config.js.docker` file and change `export default config;` to `module.exports = config;`.

This way, the config for docker is exported the same way as the normal config, where we use `module.exports = {` and the whole config object.

### Acceptance Criteria
- Wallet headless should work in docker just like it does when using `npm start`.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
