### PR TITLE
ci: push docker image to AWS ECR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
     - v*
+    branches:
+    - ci/push-images-to-ecr
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,27 +30,27 @@ jobs:
 
             tags.add(base_dockerhub_tag + version)
             tags.add(base_dockerhub_tag + 'latest')
-          else:
-            raise ValueError("Was not triggered by a git tag. Refusing to build image.")
+        else:
+            tags.add(base_ecr_tag + 'dev-${{ github.sha }}-' + timestamp)
 
         print("::set-output name=tags::" + ",".join(tags))
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8  # v2.0.0
+      uses: docker/setup-qemu-action@2  # we are trusting the action creator when using tags like this
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
+      uses: docker/setup-buildx-action@2  # we are trusting the action creator when using tags like this
     - name: Login to DockerHub
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
+      uses: docker/login-action@2  # we are trusting the action creator when using tags like this
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to AWS ECR
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
+      uses: docker/login-action@2  # we are trusting the action creator when using tags like this
       with:
           registry: ${{ secrets.AWS_ECR_URL}}
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push
-      uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8  # v3.0.0
+      uses: docker/build-push-action@3  # we are trusting the action creator when using tags like this
       with:
         push: true
         tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
     - v*
-    branches:
-    - ci/push-images-to-ecr
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,22 +35,22 @@ jobs:
 
         print("::set-output name=tags::" + ",".join(tags))
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@2  # we are trusting the action creator when using tags like this
+      uses: docker/setup-qemu-action@v2  # we are trusting the action creator when using tags like this
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@2  # we are trusting the action creator when using tags like this
+      uses: docker/setup-buildx-action@v2  # we are trusting the action creator when using tags like this
     - name: Login to DockerHub
-      uses: docker/login-action@2  # we are trusting the action creator when using tags like this
+      uses: docker/login-action@v2  # we are trusting the action creator when using tags like this
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to AWS ECR
-      uses: docker/login-action@2  # we are trusting the action creator when using tags like this
+      uses: docker/login-action@v2  # we are trusting the action creator when using tags like this
       with:
           registry: ${{ secrets.AWS_ECR_URL}}
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push
-      uses: docker/build-push-action@3  # we are trusting the action creator when using tags like this
+      uses: docker/build-push-action@v3  # we are trusting the action creator when using tags like this
       with:
         push: true
         tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,23 +7,51 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Set output
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+    - name: Prepare tags
+      id: tags
+      shell: python
+      run: |
+        import datetime
+
+        timestamp = str(int(datetime.datetime.now().timestamp()))
+        base_ecr_tag = '${{ secrets.AWS_ECR_URL }}:'
+        base_dockerhub_tag = 'docker.io/hathornetwork/hathor-wallet-headless:'
+
+        tags = set()
+
+        ref = '${{ github.ref }}'
+        if ref.startswith('refs/tags/'):
+            version = ref[10:].split('-', 1)[0]
+
+            tags.add(base_ecr_tag + version)
+            tags.add(base_ecr_tag + 'latest')
+
+            tags.add(base_dockerhub_tag + version)
+            tags.add(base_dockerhub_tag + 'latest')
+          else:
+            raise ValueError("Was not triggered by a git tag. Refusing to build image.")
+
+        print("::set-output name=tags::" + ",".join(tags))
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8  # v2.0.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
     - name: Login to DockerHub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Login to AWS ECR
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
+      with:
+          registry: ${{ secrets.AWS_ECR_URL}}
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push
-      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8  # v3.0.0
       with:
         push: true
-        tags: hathornetwork/hathor-wallet-headless:latest,hathornetwork/hathor-wallet-headless:${{ steps.vars.outputs.tag }}
+        tags: ${{ steps.tags.outputs.tags }}
         platforms: linux/amd64,linux/arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
### Acceptance Criteria
- Push the Docker image to AWS ECR
- Use newest versions of the Docker actions for Github

Test execution: https://github.com/HathorNetwork/hathor-wallet-headless/runs/7339655008?check_suite_focus=true

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
