### PR TITLE
feat: add errorCode in the response for when some wallets are already started

### DIFF
--- a/__tests__/start.test.js
+++ b/__tests__/start.test.js
@@ -39,6 +39,23 @@ describe('start api', () => {
     expect(response.body.success).toBeFalsy();
   });
 
+  it('should not start two wallets with same wallet-id', async () => {
+    // First start
+    const response = await TestUtils.request
+      .post('/start')
+      .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBeTruthy();
+
+    // Second start
+    const response2 = await TestUtils.request
+      .post('/start')
+      .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
+    expect(response2.status).toBe(200);
+    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.errorCode).toEqual("WALLET_ALREADY_STARTED")
+  });
+
   it('should accept pre-calculated addresses', async () => {
     const walletHttpInput = {
       'wallet-id': walletId,

--- a/__tests__/start.test.js
+++ b/__tests__/start.test.js
@@ -53,7 +53,7 @@ describe('start api', () => {
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
     expect(response2.status).toBe(200);
     expect(response2.body.success).toBeFalsy();
-    expect(response2.body.errorCode).toEqual("WALLET_ALREADY_STARTED")
+    expect(response2.body.errorCode).toEqual('WALLET_ALREADY_STARTED');
   });
 
   it('should accept pre-calculated addresses', async () => {

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -89,6 +89,10 @@ const apiDoc = {
                     summary: 'No wallet id parameter',
                     value: { success: false, message: "Parameter 'wallet-id' is required." }
                   },
+                  'wallet-already-started': {
+                    summary: 'Wallet with same id was already started.',
+                    value: { success: false, message: 'Failed to start wallet with id X', errorCode: 'WALLET_ALREADY_STARTED' }
+                  },
                   'start-failed': {
                     summary: 'Wallet failed to start.',
                     value: { success: false, message: 'Failed to start wallet with id X' }

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -168,7 +168,7 @@ function start(req, res) {
     console.error('Error starting wallet because this wallet-id is already in use. You must stop the wallet first.');
     res.send({
       success: false,
-      message: `Failed to start wallet with wallet id ${walletID}`,
+      message: `There is a wallet already with wallet id ${walletID}`,
     });
     return;
   }

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -168,7 +168,7 @@ function start(req, res) {
     console.error('Error starting wallet because this wallet-id is already in use. You must stop the wallet first.');
     res.send({
       success: false,
-      message: `There is a wallet already with wallet id ${walletID}`,
+      message: `Failed to start wallet with wallet id ${walletID}`,
     });
     return;
   }

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -9,6 +9,7 @@ const { walletUtils, errors, Connection, HathorWallet } = require('@hathor/walle
 const apiDocs = require('../api-docs');
 const config = require('../config');
 const { initializedWallets } = require('../services/wallets.service');
+const { API_ERROR_CODES } = require('../helpers/constants');
 
 function welcome(req, res) {
   res.send('<html><body><h1>Welcome to Hathor Wallet API!</h1>'
@@ -169,6 +170,7 @@ function start(req, res) {
     res.send({
       success: false,
       message: `Failed to start wallet with wallet id ${walletID}`,
+      errorCode: API_ERROR_CODES.WALLET_ALREADY_STARTED
     });
     return;
   }

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -8,6 +8,10 @@
 // eslint-disable-next-line import/no-import-module-exports
 import { HathorWallet } from '@hathor/wallet-lib';
 
+const API_ERROR_CODES = Object.freeze({
+  WALLET_ALREADY_STARTED: 'WALLET_ALREADY_STARTED'
+})
+
 module.exports = {
   friendlyWalletState: {
     [HathorWallet.CLOSED]: 'Closed',
@@ -18,5 +22,6 @@ module.exports = {
   },
 
   // Error message when the user tries to send a transaction while the lock is active
-  cantSendTxErrorMessage: 'You already have a transaction being sent. Please wait until it\'s done to send another.'
+  cantSendTxErrorMessage: 'You already have a transaction being sent. Please wait until it\'s done to send another.',
+  API_ERROR_CODES,
 };

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -10,7 +10,7 @@ import { HathorWallet } from '@hathor/wallet-lib';
 
 const API_ERROR_CODES = Object.freeze({
   WALLET_ALREADY_STARTED: 'WALLET_ALREADY_STARTED'
-})
+});
 
 module.exports = {
   friendlyWalletState: {


### PR DESCRIPTION
### Acceptance Criteria
- We should add an `errorCode` field in the response of the `/start` endpoint, so the client knows that the error happened because the wallet was already started


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
