### PR TITLE
fix: add scripts folder to docker image folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY .babelrc package.json package-lock.json ./
 RUN npm install
 
 COPY ./src/ ./src/
+COPY ./scripts/ ./scripts/
 COPY config.js.docker ./src/config.js
 
 EXPOSE 8000


### PR DESCRIPTION
### Motivation

Newer docker images (since v0.13.0) have a bug when running commands that are inside `scripts` folder because it was recently created. We must copy this folder to the docker image as we do with the `src` folder.

### Acceptance Criteria
- Command `npm run generate_words` should work using docker.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
