### PR TITLE
ci: push staging images / create release guide

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
     - v*
+    branches:
+    - master
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,6 +30,8 @@ jobs:
 
             tags.add(base_dockerhub_tag + version)
             tags.add(base_dockerhub_tag + 'latest')
+        elif ref == 'refs/heads/master':
+            tags.add(base_ecr_tag + 'staging-${{ github.sha }}-' + timestamp)
         else:
             tags.add(base_ecr_tag + 'dev-${{ github.sha }}-' + timestamp)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,13 @@
+# Releasing the wallet-headless
+
+Follow these steps to create a new release of hathor-wallet-headless:
+
+1. Make sure the API Docs in `src/api-docs.js` were updated in case any change in the API is made in this release.
+
+1. Create a PR to the `dev` branch to bump the versions in `package.json` and `package-lock.json`. We follow the [semantic versioning](https://semver.org/) directives when assigning versions.
+
+1. Create a Release PR from `dev` to `master` and merge it.
+
+1. Test the new version before creating the tag by following [this guide](https://github.com/HathorNetwork/ops-tools/blob/master/docs/sops/hathor-wallet-headless.md#testing-new-versions-with-wallets-monitor)
+
+1. Create a new Release in Github, and tag it with the same version as in step 2. It will trigger a build of the new Docker image to Dockerhub.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,7 @@
 
 Follow these steps to create a new release of hathor-wallet-headless:
 
-1. Make sure the API Docs in `src/api-docs.js` were updated in case any change in the API is made in this release.
-
-1. Create a PR to the `dev` branch to bump the versions in `package.json` and `package-lock.json`. We follow the [semantic versioning](https://semver.org/) directives when assigning versions.
+1. Create a PR to the `dev` branch to bump the versions in `package.json`, `package-lock.json` and `src/api-docs.js`. We follow the [semantic versioning](https://semver.org/) directives when assigning versions.
 
 1. Create a Release PR from `dev` to `master` and merge it.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,8 @@
 
 Follow these steps to create a new release of hathor-wallet-headless:
 
+1. Make sure the API Docs in `src/api-docs.js` were updated in case any change in the API is made in this release.
+
 1. Create a PR to the `dev` branch to bump the versions in `package.json`, `package-lock.json` and `src/api-docs.js`. We follow the [semantic versioning](https://semver.org/) directives when assigning versions.
 
 1. Create a Release PR from `dev` to `master` and merge it.

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -6,7 +6,7 @@ const apiDoc = {
   info: {
     title: 'Headless Hathor Wallet API',
     description: 'This wallet is fully controlled through an HTTP API.',
-    version: '0.8.2',
+    version: '0.15.0',
   },
   produces: ['application/json'],
   components: {


### PR DESCRIPTION
### Acceptance Criteria
- We should push Docker images to ECR tagged with `staging-` tags when commits are made to master
- We should have a release guide

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
