### PR TITLE
feat: add new endpoint to return token configuration string

### DIFF
--- a/__tests__/__fixtures__/http-fixtures.js
+++ b/__tests__/__fixtures__/http-fixtures.js
@@ -937,4 +937,23 @@ export default {
       timestamp: 123456,
     },
   },
+  '/thin_wallet/token': {
+    name: 'Test 1',
+    symbol: 'TST1',
+    success: true,
+    mint: [
+      {
+        tx_id: '007c9d497135e10dcba984f0b893804d7cb06721c800064cfbe05fafc138faca',
+        index: 1
+      }
+    ],
+    melt: [
+      {
+        tx_id: '007c9d497135e10dcba984f0b893804d7cb06721c800064cfbe05fafc138faca',
+        index: 2
+      }
+    ],
+    total: 100,
+    transactions_count: 1
+  },
 };

--- a/__tests__/configuration_string.test.js
+++ b/__tests__/configuration_string.test.js
@@ -3,14 +3,14 @@ import TestUtils from './test-utils';
 describe('configuration string', () => {
   it('should return 400 without a token parameter', async () => {
     const response = await TestUtils.request
-      .get('/configuration-string')
+      .get('/configuration-string');
     expect(response.status).toBe(400);
   });
 
   it('should return 200 with token in parameter', async () => {
     const response = await TestUtils.request
       .get('/configuration-string')
-      .query({ token: '1234' })
+      .query({ token: '1234' });
     expect(response.status).toBe(200);
   });
 });

--- a/__tests__/configuration_string.test.js
+++ b/__tests__/configuration_string.test.js
@@ -1,0 +1,16 @@
+import TestUtils from './test-utils';
+
+describe('configuration string', () => {
+  it('should return 400 without a token parameter', async () => {
+    const response = await TestUtils.request
+      .get('/configuration-string')
+    expect(response.status).toBe(400);
+  });
+
+  it('should return 200 with token in parameter', async () => {
+    const response = await TestUtils.request
+      .get('/configuration-string')
+      .query({ token: '1234' })
+    expect(response.status).toBe(200);
+  });
+});

--- a/__tests__/integration/configuration-string.test.js
+++ b/__tests__/integration/configuration-string.test.js
@@ -7,7 +7,7 @@ describe('configuration string', () => {
   // the code here to inject funds to test something that is already being tested
   it('should return 400 without required token parameter', async done => {
     const response = await TestUtils.request
-      .get('/configuration-string')
+      .get('/configuration-string');
 
     expect(response.status).toBe(400);
     done();

--- a/__tests__/integration/configuration-string.test.js
+++ b/__tests__/integration/configuration-string.test.js
@@ -1,0 +1,23 @@
+import { TestUtils } from './utils/test-utils-integration';
+
+describe('configuration string', () => {
+  // The success test is already done in the create token and create nft tests
+  // after a token is created, then we get the configuration string and validate it
+  // I won't replicate this test here because it would introduce more complexity in
+  // the code here to inject funds to test something that is already being tested
+  it('should return 400 without required token parameter', async done => {
+    const response = await TestUtils.request
+      .get('/configuration-string')
+
+    expect(response.status).toBe(400);
+    done();
+  });
+
+  it('should have an error with invalid token uid', async done => {
+    // Using all the create token integration test context to test this invalid configuration
+    // string request to prevent the need for creating a new file just for that
+    const invalidConfigStringResponse = await TestUtils.getConfigurationString('1234');
+    expect(invalidConfigStringResponse.success).toBe(false);
+    done();
+  });
+});

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,7 +1,7 @@
+import { tokensUtils } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
-import { tokensUtils } from '@hathor/wallet-lib';
 
 describe('create-nft routes', () => {
   /** @type WalletHelper */
@@ -83,7 +83,8 @@ describe('create-nft routes', () => {
     expect(response.body.success).toBe(true);
     const nftTx = response.body;
     expect(nftTx.hash).toBeDefined();
-    expect(nftTx.configurationString).toBe(tokensUtils.getConfigurationString(nftTx.hash, nftData.name, nftData.symbol));
+    expect(nftTx.configurationString)
+      .toBe(tokensUtils.getConfigurationString(nftTx.hash, nftData.name, nftData.symbol));
 
     const configString = await TestUtils.getConfigurationString(nftTx.hash);
     expect(nftTx.configurationString).toBe(configString);

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -86,8 +86,8 @@ describe('create-nft routes', () => {
     expect(nftTx.configurationString)
       .toBe(tokensUtils.getConfigurationString(nftTx.hash, nftData.name, nftData.symbol));
 
-    const configString = await TestUtils.getConfigurationString(nftTx.hash);
-    expect(nftTx.configurationString).toBe(configString);
+    const configStringResponse = await TestUtils.getConfigurationString(nftTx.hash);
+    expect(nftTx.configurationString).toBe(configStringResponse.configurationString);
 
     // No authority tokens
     for (const output of nftTx.outputs) {

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,6 +1,7 @@
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
+import { tokensUtils } from '@hathor/wallet-lib';
 
 describe('create-nft routes', () => {
   /** @type WalletHelper */
@@ -82,6 +83,10 @@ describe('create-nft routes', () => {
     expect(response.body.success).toBe(true);
     const nftTx = response.body;
     expect(nftTx.hash).toBeDefined();
+    expect(nftTx.configurationString).toBe(tokensUtils.getConfigurationString(nftTx.hash, nftData.name, nftData.symbol));
+
+    const configString = await TestUtils.getConfigurationString(nftTx.hash);
+    expect(nftTx.configurationString).toBe(configString);
 
     // No authority tokens
     for (const output of nftTx.outputs) {

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,8 +1,8 @@
+import { tokensUtils } from '@hathor/wallet-lib';
 import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
-import { tokensUtils } from '@hathor/wallet-lib';
 
 describe('create token', () => {
   let wallet1;
@@ -191,7 +191,8 @@ describe('create token', () => {
 
     expect(response.body.success).toBe(true);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.configurationString).toBe(tokensUtils.getConfigurationString(response.body.hash, tokenA.name, tokenA.symbol));
+    expect(response.body.configurationString)
+      .toBe(tokensUtils.getConfigurationString(response.body.hash, tokenA.name, tokenA.symbol));
 
     const configString = await TestUtils.getConfigurationString(response.body.hash);
     expect(response.body.configurationString).toBe(configString);

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -2,6 +2,7 @@ import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
+import { tokensUtils } from '@hathor/wallet-lib';
 
 describe('create token', () => {
   let wallet1;
@@ -190,6 +191,10 @@ describe('create token', () => {
 
     expect(response.body.success).toBe(true);
     expect(response.body.hash).toBeDefined();
+    expect(response.body.configurationString).toBe(tokensUtils.getConfigurationString(response.body.hash, tokenA.name, tokenA.symbol));
+
+    const configString = await TestUtils.getConfigurationString(response.body.hash);
+    expect(response.body.configurationString).toBe(configString);
 
     await TestUtils.pauseForWsUpdate();
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -195,6 +195,7 @@ describe('create token', () => {
       .toBe(tokensUtils.getConfigurationString(response.body.hash, tokenA.name, tokenA.symbol));
 
     const configStringResponse = await TestUtils.getConfigurationString(response.body.hash);
+    expect(response.body.success).toBe(true);
     expect(response.body.configurationString).toBe(configStringResponse.configurationString);
 
     await TestUtils.pauseForWsUpdate();

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -194,8 +194,8 @@ describe('create token', () => {
     expect(response.body.configurationString)
       .toBe(tokensUtils.getConfigurationString(response.body.hash, tokenA.name, tokenA.symbol));
 
-    const configString = await TestUtils.getConfigurationString(response.body.hash);
-    expect(response.body.configurationString).toBe(configString);
+    const configStringResponse = await TestUtils.getConfigurationString(response.body.hash);
+    expect(response.body.configurationString).toBe(configStringResponse.configurationString);
 
     await TestUtils.pauseForWsUpdate();
 

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -685,4 +685,17 @@ export class TestUtils {
 
     return transaction;
   }
+
+  /**
+   * Returns the configuration string of a token
+   * @param {string} token Token uid to get configuration string
+   * @returns {Promise<{ configurationString: string }>}
+   */
+  static async getConfigurationString(token) {
+    const response = await TestUtils.request
+      .get('/configuration-string')
+      .query({ token });
+
+    return response.body;
+  }
 }

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -202,6 +202,7 @@ class TestUtils {
     httpMock.onPost('push_tx').reply(200, httpFixtures['/v1a/push_tx']);
     httpMock.onPost('submit-job').reply(200, httpFixtures['submit-job']);
     httpMock.onGet('job-status').reply(200, httpFixtures['job-status']);
+    httpMock.onGet('/thin_wallet/token').reply(200, httpFixtures['/thin_wallet/token']);
 
     // websocket mocks
     wsMock.on('connection', socket => {

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -1173,7 +1173,7 @@ const apiDoc = {
                   },
                   success: {
                     summary: 'Success',
-                    value: { hash: '00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277', nonce: 200, timestamp: 1610730485, version: 2, weight: 8.000001, parents: ['006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d', '001ac1d7ff68e9bf4bf67b81fee517f08b06be564d7a28b13e41fea158b4cf54'], inputs: [{ tx_id: '00efbc1f99dc50a3c7ff7e7193ebfaa3df28eec467bcd0555eaf703ae773ab5c', index: 1, data: 'RzBFAiEAxFEPpgauWvPzCoM3zknUdOsWL2RwBu8JSOS6yKGufRICIAOf/mKgLka73wiwXUzVLC/kMYXKmqYSnA2oki6pm9qBIQOyMiKwc3u+O4mBUuN7BFLMwW9hmvUL+KmYPr1N0fl8ww==' }], outputs: [{ value: 6290, token_data: 0, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1000, token_data: 1, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1, token_data: 129, script: 'dqkUL2o1cHLbOQZfj+yVFP0rof9S+WGIrA==' }, { value: 2, token_data: 129, script: 'dqkUVawHzE0m6oUvfyzz2cAUdvYlP/SIrA==' }], tokens: [], token_name: 'Test', token_symbol: 'TST' }
+                    value: { hash: '00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277', nonce: 200, timestamp: 1610730485, version: 2, weight: 8.000001, parents: ['006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d', '001ac1d7ff68e9bf4bf67b81fee517f08b06be564d7a28b13e41fea158b4cf54'], inputs: [{ tx_id: '00efbc1f99dc50a3c7ff7e7193ebfaa3df28eec467bcd0555eaf703ae773ab5c', index: 1, data: 'RzBFAiEAxFEPpgauWvPzCoM3zknUdOsWL2RwBu8JSOS6yKGufRICIAOf/mKgLka73wiwXUzVLC/kMYXKmqYSnA2oki6pm9qBIQOyMiKwc3u+O4mBUuN7BFLMwW9hmvUL+KmYPr1N0fl8ww==' }], outputs: [{ value: 6290, token_data: 0, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1000, token_data: 1, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1, token_data: 129, script: 'dqkUL2o1cHLbOQZfj+yVFP0rof9S+WGIrA==' }, { value: 2, token_data: 129, script: 'dqkUVawHzE0m6oUvfyzz2cAUdvYlP/SIrA==' }], tokens: [], token_name: 'Test', token_symbol: 'TST', configurationString: '[Test:TST:00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277:a233sac]' }
                   },
                   'wallet-not-ready': {
                     summary: 'Wallet is not ready yet',
@@ -1470,7 +1470,7 @@ const apiDoc = {
                   },
                   success: {
                     summary: 'Success',
-                    value: { hash: '00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277', nonce: 200, timestamp: 1610730485, version: 2, weight: 8.000001, parents: ['006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d', '001ac1d7ff68e9bf4bf67b81fee517f08b06be564d7a28b13e41fea158b4cf54'], inputs: [{ tx_id: '00efbc1f99dc50a3c7ff7e7193ebfaa3df28eec467bcd0555eaf703ae773ab5c', index: 1, data: 'RzBFAiEAxFEPpgauWvPzCoM3zknUdOsWL2RwBu8JSOS6yKGufRICIAOf/mKgLka73wiwXUzVLC/kMYXKmqYSnA2oki6pm9qBIQOyMiKwc3u+O4mBUuN7BFLMwW9hmvUL+KmYPr1N0fl8ww==' }], outputs: [{ value: 6290, token_data: 0, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1000, token_data: 1, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1, token_data: 129, script: 'dqkUL2o1cHLbOQZfj+yVFP0rof9S+WGIrA==' }, { value: 2, token_data: 129, script: 'dqkUVawHzE0m6oUvfyzz2cAUdvYlP/SIrA==' }], tokens: [], token_name: 'Test', token_symbol: 'TST' }
+                    value: { hash: '00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277', nonce: 200, timestamp: 1610730485, version: 2, weight: 8.000001, parents: ['006814ba6ac14d8dc69a888dcf79e3c9ad597b31449edd086a82160698ea229d', '001ac1d7ff68e9bf4bf67b81fee517f08b06be564d7a28b13e41fea158b4cf54'], inputs: [{ tx_id: '00efbc1f99dc50a3c7ff7e7193ebfaa3df28eec467bcd0555eaf703ae773ab5c', index: 1, data: 'RzBFAiEAxFEPpgauWvPzCoM3zknUdOsWL2RwBu8JSOS6yKGufRICIAOf/mKgLka73wiwXUzVLC/kMYXKmqYSnA2oki6pm9qBIQOyMiKwc3u+O4mBUuN7BFLMwW9hmvUL+KmYPr1N0fl8ww==' }], outputs: [{ value: 6290, token_data: 0, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1000, token_data: 1, script: 'dqkUPzRQOMrZ7k25txm/8V0PVr7dGwSIrA==' }, { value: 1, token_data: 129, script: 'dqkUL2o1cHLbOQZfj+yVFP0rof9S+WGIrA==' }, { value: 2, token_data: 129, script: 'dqkUVawHzE0m6oUvfyzz2cAUdvYlP/SIrA==' }], tokens: [], token_name: 'Test', token_symbol: 'TST', configurationString: '[Test:TST:00c9b977ddb2d0256db38e6c846eac84e0cf7ab8eded2f37119d84ee6edd4277:a233sac]' }
                   },
                   'wallet-not-ready': {
                     summary: 'Wallet is not ready yet',
@@ -1907,6 +1907,41 @@ const apiDoc = {
                   'invalid-parameter': {
                     summary: 'Invalid parameter',
                     value: { success: false, error: [{ value: '"1"', msg: 'Invalid value', param: 'address', location: 'query' }] }
+                  }
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/configuration-string': {
+      get: {
+        summary: 'Get configuration string of a token.',
+        parameters: [
+          {
+            name: 'token',
+            in: 'query',
+            description: 'Token to get the configuration string.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Configuration string of the token or error in case of invalid token uid.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: { success: true, configurationString: '[Test 1:TST1:007c9d497135e10dcba984f0b893804d7cb06721c800064cfbe05fafc138faca:5dd518cc]' },
+                  },
+                  'invalid-token': {
+                    summary: 'Token uid is invalid',
+                    value: { success: false, message: 'Invalid token uid.' }
                   }
                 },
               },

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -223,7 +223,7 @@ function multisigPubkey(req, res) {
   });
 }
 
-async function getConfigurationString(req, res) {
+function getConfigurationString(req, res) {
   const validationResult = parametersValidation(req);
   if (!validationResult.success) {
     res.status(400).json(validationResult);
@@ -231,21 +231,21 @@ async function getConfigurationString(req, res) {
   }
 
   // Expects token uid
-  const token = req.query.token;
-  const result = await new Promise((resolve) => {
-    return walletApi.getGeneralTokenInfo(token, resolve);
+  const { token } = req.query;
+  walletApi.getGeneralTokenInfo(token, response => {
+    if (response.success) {
+      const { name, symbol } = response;
+      res.send({
+        success: true,
+        configurationString: tokensUtils.getConfigurationString(token, name, symbol)
+      });
+    } else {
+      res.send({
+        success: false,
+        message: 'Invalid token uid.',
+      });
+    }
   });
-
-  if (!result.success) {
-    res.send({
-      success: false,
-      message: 'Invalid token uid.',
-    });
-    return;
-  }
-
-  const { name, symbol } = result;
-  res.send({ configurationString: tokensUtils.getConfigurationString(token, name, symbol) });
 }
 
 module.exports = {

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -391,7 +391,11 @@ async function createToken(req, res) {
   const changeAddress = req.body.change_address || null;
   try {
     const response = await wallet.createNewToken(name, symbol, amount, { changeAddress, address });
-    const configurationString = tokensUtils.getConfigurationString(response.hash, response.name, response.symbol);
+    const configurationString = tokensUtils.getConfigurationString(
+      response.hash,
+      response.name,
+      response.symbol
+    );
     res.send({ success: true, configurationString, ...mapTxReturn(response) });
   } catch (err) {
     res.send({ success: false, error: err.message });
@@ -534,7 +538,11 @@ async function createNft(req, res) {
       data,
       { address, changeAddress, createMint, createMelt }
     );
-    const configurationString = tokensUtils.getConfigurationString(response.hash, response.name, response.symbol);
+    const configurationString = tokensUtils.getConfigurationString(
+      response.hash,
+      response.name,
+      response.symbol
+    );
     res.send({ success: true, configurationString, ...mapTxReturn(response) });
   } catch (err) {
     res.send({ success: false, error: err.message });

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { constants: hathorLibConstants, helpersUtils, errors } = require('@hathor/wallet-lib');
+const { constants: hathorLibConstants, helpersUtils, errors, tokensUtils } = require('@hathor/wallet-lib');
 const { matchedData } = require('express-validator');
 const { parametersValidation } = require('../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../lock');
@@ -391,7 +391,8 @@ async function createToken(req, res) {
   const changeAddress = req.body.change_address || null;
   try {
     const response = await wallet.createNewToken(name, symbol, amount, { changeAddress, address });
-    res.send({ success: true, ...mapTxReturn(response) });
+    const configurationString = tokensUtils.getConfigurationString(response.hash, response.name, response.symbol);
+    res.send({ success: true, configurationString, ...mapTxReturn(response) });
   } catch (err) {
     res.send({ success: false, error: err.message });
   } finally {
@@ -533,7 +534,8 @@ async function createNft(req, res) {
       data,
       { address, changeAddress, createMint, createMelt }
     );
-    res.send({ success: true, ...mapTxReturn(response) });
+    const configurationString = tokensUtils.getConfigurationString(response.hash, response.name, response.symbol);
+    res.send({ success: true, configurationString, ...mapTxReturn(response) });
   } catch (err) {
     res.send({ success: false, error: err.message });
   } finally {

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,13 @@ export const initHathorLib = () => {
   // We use this string to parse the version from user agent
   // in some of our services, so changing this might break another service
   hathorLibConfig.setUserAgent(`Hathor Wallet Headless / ${version}`);
+
+  // Those configurations will be set when starting the wallet
+  // however we can already set them because they are fixed
+  // for all wallets and it's useful if we need to run any request
+  // to the full node before starting a wallet
+  hathorLibConfig.setServerUrl(config.server);
+  hathorLibConfig.setNetwork(config.network);
 };
 
 initHathorLib();

--- a/src/routes/index.routes.js
+++ b/src/routes/index.routes.js
@@ -6,6 +6,7 @@
  */
 
 const { Router } = require('express');
+const { query } = require('express-validator');
 const rootControllers = require('../controllers/index.controller');
 
 const mainRouter = Router({ mergeParams: true });
@@ -15,6 +16,17 @@ mainRouter.get('/', rootControllers.welcome);
 mainRouter.get('/docs', rootControllers.docs);
 mainRouter.post('/start', rootControllers.start);
 mainRouter.post('/multisig-pubkey', rootControllers.multisigPubkey);
+
+/**
+ * GET request to get the configuration string of a token
+ * For the docs, see api-docs.js
+ */
+mainRouter.get(
+  '/configuration-string',
+  query('token').isString(),
+  rootControllers.getConfigurationString
+);
+
 mainRouter.use('/wallet', walletRouter);
 
 mainRouter.use((err, req, res, next) => {


### PR DESCRIPTION
### Acceptance Criteria

- Add the token configuration string in the response of the endpoints to create token and create NFT.
- Add new endpoint to get a configuration string of a given token from its uid.
- Add tests for the new endpoint and the new response field in old APIs.
- Update API docs.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
