### PR TITLE
chore: bump wallet lib to v0.42.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,9 +1197,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.41.1.tgz",
-      "integrity": "sha512-s+bwie+8FLC7cPyX2LtYrCut9QmmRplAiwTxy2+D2VhTbBeydjlI8GWKFgpqm7TOQ2yzRYwz516tGqOCVJjfNg==",
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.42.1.tgz",
+      "integrity": "sha512-leJCuHyQD1dyKEhsN6DAlUUCGw51d6ThEfGwz/R6sXhiXmmrxiMWwYyaIrLBIRASkdlvbxAQgnGIl0V5wxO8KA==",
       "requires": {
         "axios": "^0.21.4",
         "bitcore-lib": "^8.25.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Hathor Wallet Headless, i.e., without graphical user interface",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/node": "^7.13.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/preset-env": "^7.13.5",
-    "@hathor/wallet-lib": "^0.41.1",
+    "@hathor/wallet-lib": "^0.42.1",
     "express-validator": "^6.10.0",
     "express": "^4.17.1",
     "lodash": "^4.17.11",

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -6,7 +6,7 @@ const apiDoc = {
   info: {
     title: 'Headless Hathor Wallet API',
     description: 'This wallet is fully controlled through an HTTP API.',
-    version: '0.19.0',
+    version: '0.19.1',
   },
   produces: ['application/json'],
   components: {


### PR DESCRIPTION
# Acceptance Criteria

- Bump wallet lib to v0.42.1
- Bump headless to v0.19.1