### PR TITLE
fix: import logger module with ES6 syntax

### DIFF
--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -1,5 +1,6 @@
 import TestUtils from './test-utils';
 import { MAX_DATA_SCRIPT_LENGTH } from '../src/constants';
+import { HathorWallet } from '@hathor/wallet-lib';
 
 const walletId = 'stub_send_tx';
 
@@ -320,5 +321,22 @@ describe('send-tx api', () => {
     expect(response2.status).toBe(200);
     expect(response2.body.hash).toBeTruthy();
     expect(response2.body.success).toBeTruthy();
+  });
+
+  it('should log errors on send-tx when debug=true on req.body', async () => {
+    const spy = jest.spyOn(HathorWallet.prototype, 'sendManyOutputsTransaction').mockImplementation(() => {
+      throw new Error('Boom!');
+    });
+    const response = await TestUtils.request
+      .post('/wallet/send-tx')
+      .send({
+        debug: true,
+        outputs: [{ address: 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc', value: 1 }],
+      })
+      .set({ 'x-wallet-id': walletId });
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBeFalsy();
+    expect(response.body.error).toEqual('Boom!');
+    spy.mockRestore();
   });
 });

--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -1,6 +1,6 @@
+import { HathorWallet } from '@hathor/wallet-lib';
 import TestUtils from './test-utils';
 import { MAX_DATA_SCRIPT_LENGTH } from '../src/constants';
-import { HathorWallet } from '@hathor/wallet-lib';
 
 const walletId = 'stub_send_tx';
 

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -362,9 +362,9 @@ async function sendTx(req, res) {
   } catch (err) {
     const ret = { success: false, error: err.message };
     if (debug) {
-      logger.debug('/send-tx failed', {
-        body: req.body,
-        response: ret,
+      console.debug('/send-tx failed', {
+        body: JSON.stringify(req.body),
+        response: JSON.stringify(ret),
       });
     }
     res.send(ret);

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -361,6 +361,7 @@ async function sendTx(req, res) {
     res.send({ success: true, ...mapTxReturn(response) });
   } catch (err) {
     const ret = { success: false, error: err.message };
+    /* istanbul ignore if */
     if (debug) {
       console.debug('/send-tx failed', {
         body: JSON.stringify(req.body),

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// The import is used because there is an issue with winston logger when importing with require ref: #262
+// import is used because there is an issue with winston logger when using require ref: #262
 import logger from '../../logger'; // eslint-disable-line import/no-import-module-exports
 
 const { txApi, walletApi, constants: hathorLibConstants, helpersUtils, errors, tokensUtils, PartialTx } = require('@hathor/wallet-lib');

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import logger from '../../logger';
+// The import is used because there is an issue with winston logger when importing with require ref: #262
+import logger from '../../logger'; // eslint-disable-line import/no-import-module-exports
+
 const { txApi, walletApi, constants: hathorLibConstants, helpersUtils, errors, tokensUtils, PartialTx } = require('@hathor/wallet-lib');
 const { matchedData } = require('express-validator');
 const { parametersValidation } = require('../../helpers/validations.helper');

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import logger from '../../logger';
 const { txApi, walletApi, constants: hathorLibConstants, helpersUtils, errors, tokensUtils, PartialTx } = require('@hathor/wallet-lib');
 const { matchedData } = require('express-validator');
 const { parametersValidation } = require('../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../lock');
 const { cantSendTxErrorMessage, friendlyWalletState } = require('../../helpers/constants');
 const { mapTxReturn, prepareTxFunds } = require('../../helpers/tx.helper');
-const logger = require('../../logger');
 const { initializedWallets } = require('../../services/wallets.service');
 
 function getStatus(req, res) {
@@ -361,9 +361,8 @@ async function sendTx(req, res) {
     res.send({ success: true, ...mapTxReturn(response) });
   } catch (err) {
     const ret = { success: false, error: err.message };
-    /* istanbul ignore if */
     if (debug) {
-      console.debug('/send-tx failed', {
+      logger.debug('/send-tx failed', {
         body: JSON.stringify(req.body),
         response: JSON.stringify(ret),
       });


### PR DESCRIPTION
### Description

If debug is enabled (sending `debug=true` on the request body) for the `/wallet/send-tx` api and we have an error sending the transaction the error will not be logged since `logger.debug` is used, but it is not a function.
This has been attributed to how we import the logger module, when using CommonJS (require syntax) the module does not export some methods (debug, info, etc.). Using ES6 (import syntax) seems to work

### Acceptance Criteria

- Import logger module with `import` instead of require

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
