### PR TITLE
feat: Listened proposals

### DIFF
--- a/__tests__/atomic-swap/atomic-swap-service.test.js
+++ b/__tests__/atomic-swap/atomic-swap-service.test.js
@@ -64,7 +64,7 @@ describe('list proposals', () => {
       .set({ 'x-wallet-id': walletId });
 
     expect(response.status).toBe(200);
-    expect(response.body).toStrictEqual([]);
+    expect(response.body).toStrictEqual({ success: true, proposals: [] });
 
     // Should work when there is an empty map for this wallet
     walletListenedProposals.set(walletId, new Map());
@@ -73,7 +73,7 @@ describe('list proposals', () => {
       .set({ 'x-wallet-id': walletId });
 
     expect(response.status).toBe(200);
-    expect(response.body).toStrictEqual([]);
+    expect(response.body).toStrictEqual({ success: true, proposals: [] });
   });
 
   it('should return only the proposal ids', async () => {
@@ -83,18 +83,20 @@ describe('list proposals', () => {
       .get('/wallet/atomic-swap/tx-proposal/list')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body).toStrictEqual([
-      'prop1',
-    ]);
+    expect(response.body).toStrictEqual({
+      success: true,
+      proposals: ['prop1'],
+    });
     await atomicSwapService.addListenedProposal(walletId, 'prop2', 'pass2');
 
     response = await TestUtils.request
       .get('/wallet/atomic-swap/tx-proposal/list')
       .set({ 'x-wallet-id': walletId });
-    expect(response.body).toStrictEqual([
-      'prop1',
-      'prop2',
-    ]);
+    expect(response.body)
+      .toStrictEqual({
+        success: true,
+        proposals: ['prop1', 'prop2'],
+      });
   });
 });
 

--- a/__tests__/atomic-swap/atomic-swap-service.test.js
+++ b/__tests__/atomic-swap/atomic-swap-service.test.js
@@ -1,0 +1,152 @@
+import hathorLib from '@hathor/wallet-lib';
+import TestUtils from '../test-utils';
+import { addListenedProposal } from '../../src/services/atomic-swap.service';
+import { walletListenedProposals } from '../../src/services/wallets.service';
+
+const walletId = 'stub_atomic_swap_service';
+const fakeTxId = '00003392e185c6e72d7d8073ef94649023777fd23c828514f505a7955abf0caf';
+const fakeUid = '0000219a831aaa7b011973981a286142b3002cd04763002e23ba6fec7dadda44';
+const spyApi = jest.spyOn(hathorLib.txApi, 'getTransaction');
+const spyUtxos = jest.spyOn(hathorLib.HathorWallet.prototype, 'getAllUtxos');
+function* mockUtxos(options) {
+  yield {
+    txId: fakeTxId,
+    index: 0,
+    tokenId: hathorLib.constants.HATHOR_TOKEN_CONFIG.uid,
+    value: 10,
+    address: TestUtils.addresses[0],
+    timelock: null,
+    locked: false,
+    authorities: 0,
+    heightlock: null,
+    addressPath: 'm/fake/bip32/path',
+  };
+}
+
+beforeAll(async () => {
+  await TestUtils.startWallet({ walletId, preCalculatedAddresses: TestUtils.addresses });
+  spyApi.mockImplementation(async (txId, cb) => {
+    cb({
+      success: true,
+      tx: {
+        tokens: [{ uid: fakeUid }],
+        outputs: [
+          {
+            value: 10,
+            token: hathorLib.constants.HATHOR_TOKEN_CONFIG.uid,
+            token_data: 0,
+            decoded: { address: TestUtils.addresses[0] },
+          },
+          {
+            value: 10,
+            token: fakeUid,
+            token_data: 1,
+            decoded: { address: TestUtils.addresses[1] },
+          },
+        ]
+      },
+    });
+  });
+  spyUtxos.mockImplementation(mockUtxos);
+});
+
+afterAll(async () => {
+  await TestUtils.stopWallet({ walletId });
+  spyApi.mockRestore();
+  spyUtxos.mockRestore();
+});
+describe('list proposals', () => {
+  it('should return an empty array for no listened proposals', async () => {
+    // Should work when there is no map for this wallet
+    walletListenedProposals.delete(walletId);
+    let response = await TestUtils.request
+      .get('/wallet/atomic-swap/tx-proposal/list')
+      .set({ 'x-wallet-id': walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual([]);
+
+    // Should work when there is an empty map for this wallet
+    walletListenedProposals.set(walletId, new Map());
+    response = await TestUtils.request
+      .get('/wallet/atomic-swap/tx-proposal/list')
+      .set({ 'x-wallet-id': walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual([]);
+  });
+
+  it('should return only the proposal ids', async () => {
+    await addListenedProposal(walletId, 'prop1', 'pass1');
+
+    let response = await TestUtils.request
+      .get('/wallet/atomic-swap/tx-proposal/list')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual([
+      'prop1',
+    ]);
+    await addListenedProposal(walletId, 'prop2', 'pass2');
+
+    response = await TestUtils.request
+      .get('/wallet/atomic-swap/tx-proposal/list')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.body).toStrictEqual([
+      'prop1',
+      'prop2',
+    ]);
+  });
+});
+
+describe('remove proposals', () => {
+  it('should work when there are no proposals', async () => {
+    // Should work when there is no map for this wallet
+    walletListenedProposals.delete(walletId);
+
+    let response = await TestUtils.request
+      .delete('/wallet/atomic-swap/tx-proposal/delete/prop-1')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.body).toStrictEqual({ success: true });
+
+    // Should work when there is an empty map for this wallet
+    walletListenedProposals.set(walletId, new Map());
+    response = await TestUtils.request
+      .delete('/wallet/atomic-swap/tx-proposal/delete/prop-1')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.body).toStrictEqual({ success: true });
+  });
+
+  it('should return success for an existing map', async () => {
+    // Configuring the wallet before the test
+    walletListenedProposals.set(walletId, new Map());
+    const listenedProposals = walletListenedProposals.get(walletId);
+    listenedProposals.set('prop-2', {
+      id: 'prop-2',
+      password: '123'
+    });
+
+    // Removing an unexistent proposal
+    let response = await TestUtils.request
+      .delete('/wallet/atomic-swap/tx-proposal/delete/prop-1')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.body).toStrictEqual({ success: true });
+    expect(listenedProposals.size).toEqual(1);
+
+    // Removing a proposal that is being listened to
+    response = await TestUtils.request
+      .delete('/wallet/atomic-swap/tx-proposal/delete/prop-2')
+      .set({ 'x-wallet-id': walletId });
+    expect(response.body).toStrictEqual({ success: true });
+    expect(listenedProposals.size).toEqual(0);
+  });
+
+  it('should remove the wallet from the proposals map when it is stopped', async () => {
+    expect(walletListenedProposals.has(walletId)).toEqual(true);
+
+    await TestUtils.request
+      .post('/wallet/stop')
+      .set({ 'x-wallet-id': walletId });
+
+    expect(walletListenedProposals.has(walletId)).toEqual(false);
+  });
+});

--- a/__tests__/atomic-swap/atomic-swap-service.test.js
+++ b/__tests__/atomic-swap/atomic-swap-service.test.js
@@ -1,7 +1,6 @@
 import hathorLib from '@hathor/wallet-lib';
 import TestUtils from '../test-utils';
 import atomicSwapService from '../../src/services/atomic-swap.service';
-import { walletListenedProposals } from '../../src/services/wallets.service';
 
 const walletId = 'stub_atomic_swap_service';
 const fakeTxId = '00003392e185c6e72d7d8073ef94649023777fd23c828514f505a7955abf0caf';
@@ -58,7 +57,7 @@ afterAll(async () => {
 describe('list proposals', () => {
   it('should return an empty array for no listened proposals', async () => {
     // Should work when there is no map for this wallet
-    walletListenedProposals.delete(walletId);
+    atomicSwapService.walletListenedProposals.delete(walletId);
     let response = await TestUtils.request
       .get('/wallet/atomic-swap/tx-proposal/list')
       .set({ 'x-wallet-id': walletId });
@@ -67,7 +66,7 @@ describe('list proposals', () => {
     expect(response.body).toStrictEqual({ success: true, proposals: [] });
 
     // Should work when there is an empty map for this wallet
-    walletListenedProposals.set(walletId, new Map());
+    atomicSwapService.walletListenedProposals.set(walletId, new Map());
     response = await TestUtils.request
       .get('/wallet/atomic-swap/tx-proposal/list')
       .set({ 'x-wallet-id': walletId });
@@ -103,7 +102,7 @@ describe('list proposals', () => {
 describe('remove proposals', () => {
   it('should work when there are no proposals', async () => {
     // Should work when there is no map for this wallet
-    walletListenedProposals.delete(walletId);
+    atomicSwapService.walletListenedProposals.delete(walletId);
 
     let response = await TestUtils.request
       .delete('/wallet/atomic-swap/tx-proposal/delete/prop-1')
@@ -111,7 +110,7 @@ describe('remove proposals', () => {
     expect(response.body).toStrictEqual({ success: true });
 
     // Should work when there is an empty map for this wallet
-    walletListenedProposals.set(walletId, new Map());
+    atomicSwapService.walletListenedProposals.set(walletId, new Map());
     response = await TestUtils.request
       .delete('/wallet/atomic-swap/tx-proposal/delete/prop-1')
       .set({ 'x-wallet-id': walletId });
@@ -135,8 +134,8 @@ describe('remove proposals', () => {
 
   it('should return success for an existing map', async () => {
     // Configuring the wallet before the test
-    walletListenedProposals.set(walletId, new Map());
-    const listenedProposals = walletListenedProposals.get(walletId);
+    atomicSwapService.walletListenedProposals.set(walletId, new Map());
+    const listenedProposals = atomicSwapService.walletListenedProposals.get(walletId);
     listenedProposals.set('prop-2', {
       id: 'prop-2',
       password: '123'
@@ -158,12 +157,12 @@ describe('remove proposals', () => {
   });
 
   it('should remove the wallet from the proposals map when it is stopped', async () => {
-    expect(walletListenedProposals.has(walletId)).toEqual(true);
+    expect(atomicSwapService.walletListenedProposals.has(walletId)).toEqual(true);
 
     await TestUtils.request
       .post('/wallet/stop')
       .set({ 'x-wallet-id': walletId });
 
-    expect(walletListenedProposals.has(walletId)).toEqual(false);
+    expect(atomicSwapService.walletListenedProposals.has(walletId)).toEqual(false);
   });
 });

--- a/__tests__/atomic-swap/service.test.js
+++ b/__tests__/atomic-swap/service.test.js
@@ -1,14 +1,16 @@
 import { swapService } from '@hathor/wallet-lib';
 import { serviceCreate } from '../../src/services/atomic-swap.service';
 
+const walletId = 'mock-wallet';
+
 describe('serviceCreate', () => {
   it('should reject empty proposals', async () => {
-    await expect(serviceCreate('', 'abc'))
+    await expect(serviceCreate(walletId, '', 'abc'))
       .rejects.toThrow('Invalid PartialTx');
   });
 
   it('should reject invalid passwords', async () => {
-    await expect(serviceCreate('PartialTx||', 'ab'))
+    await expect(serviceCreate(walletId, 'PartialTx||', 'ab'))
       .rejects.toThrow('Password must have at least 3 characters');
   });
 
@@ -18,7 +20,7 @@ describe('serviceCreate', () => {
         throw new Error('Unexpected lib error');
       });
 
-    await expect(serviceCreate('PartialTx||', 'abc'))
+    await expect(serviceCreate(walletId, 'PartialTx||', 'abc'))
       .rejects.toThrow('Unexpected lib error');
 
     mockLib.mockRestore();
@@ -28,7 +30,7 @@ describe('serviceCreate', () => {
     const mockLib = jest.spyOn(swapService, 'create')
       .mockImplementationOnce(async () => ({ success: false }));
 
-    await expect(serviceCreate('PartialTx||', 'abc'))
+    await expect(serviceCreate(walletId, 'PartialTx||', 'abc'))
       .rejects.toThrow('Unable to create the proposal on the Atomic Swap Service');
 
     mockLib.mockRestore();
@@ -38,7 +40,7 @@ describe('serviceCreate', () => {
     const mockLib = jest.spyOn(swapService, 'create')
       .mockImplementationOnce(async () => ({ success: true, id: 'abc' }));
 
-    const result = await serviceCreate('PartialTx||', 'abc');
+    const result = await serviceCreate(walletId, 'PartialTx||', 'abc');
     expect(result).toStrictEqual({ proposalId: 'abc' });
 
     mockLib.mockRestore();

--- a/__tests__/atomic-swap/tx-proposal-create.test.js
+++ b/__tests__/atomic-swap/tx-proposal-create.test.js
@@ -359,7 +359,7 @@ describe('create tx-proposal api', () => {
       const mockLib = jest.spyOn(swapService, 'create')
         .mockImplementationOnce(async () => ({ success: true, id: 'mock-id' }));
 
-      const response = await TestUtils.request
+      let response = await TestUtils.request
         .post('/wallet/atomic-swap/tx-proposal')
         .send({
           receive: {
@@ -378,6 +378,15 @@ describe('create tx-proposal api', () => {
         isComplete: false,
         createdProposalId: 'mock-id',
       });
+
+      // The listProposals route should confirm this proposal is being listened to now
+      response = await TestUtils.request
+        .get('/wallet/atomic-swap/tx-proposal/list')
+        .set({ 'x-wallet-id': walletId });
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual([
+        'mock-id',
+      ]);
 
       mockLib.mockRestore();
     });

--- a/__tests__/atomic-swap/tx-proposal-create.test.js
+++ b/__tests__/atomic-swap/tx-proposal-create.test.js
@@ -384,9 +384,10 @@ describe('create tx-proposal api', () => {
         .get('/wallet/atomic-swap/tx-proposal/list')
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual([
-        'mock-id',
-      ]);
+      expect(response.body).toStrictEqual({
+        success: true,
+        proposals: ['mock-id'],
+      });
 
       mockLib.mockRestore();
     });

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -350,11 +350,7 @@ async function listenedProposalList(req, res) {
   const proposalMap = await atomicSwapService.getListenedProposals(req.walletId);
 
   // Transform the map into an array of proposalIds;
-  const list = [];
-  proposalMap.forEach(proposal => {
-    list.push(proposal.id);
-  });
-
+  const list = Array.from(proposalMap.keys());
   res.send({ success: true, proposals: list });
 }
 

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -17,7 +17,8 @@ const {
 } = require('@hathor/wallet-lib');
 const {
   assembleTransaction,
-  serviceCreate
+  serviceCreate,
+  getListenedProposals
 } = require('../../../services/atomic-swap.service');
 const { parametersValidation } = require('../../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../../lock');
@@ -346,6 +347,21 @@ async function unlockInputs(req, res) {
   }
 }
 
+/**
+ * Fetches the list of proposals being listened to by this wallet on the Atomic Swap Service
+ */
+async function listenedProposalList(req, res) {
+  const proposalMap = await getListenedProposals(req.walletId);
+
+  // Transform the map into an array of proposalIds;
+  const list = [];
+  proposalMap.forEach(proposal => {
+    list.push(proposal.id);
+  });
+
+  res.send(list);
+}
+
 module.exports = {
   buildTxProposal,
   getInputData,
@@ -354,4 +370,5 @@ module.exports = {
   signAndPush,
   signTx,
   unlockInputs,
+  listenedProposalList,
 };

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -15,12 +15,7 @@ const {
   constants: { HATHOR_TOKEN_CONFIG, TOKEN_MINT_MASK, TOKEN_MELT_MASK },
   wallet: oldWallet,
 } = require('@hathor/wallet-lib');
-const {
-  assembleTransaction,
-  serviceCreate,
-  getListenedProposals,
-  removeListenedProposal,
-} = require('../../../services/atomic-swap.service');
+const atomicSwapService = require('../../../services/atomic-swap.service');
 const { parametersValidation } = require('../../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../../lock');
 const { cantSendTxErrorMessage } = require('../../../helpers/constants');
@@ -137,7 +132,7 @@ async function buildTxProposal(req, res) {
 
     let createdProposalId;
     if (constants.SWAP_SERVICE_FEATURE_TOGGLE && serviceParams.is_new) {
-      const { proposalId } = await serviceCreate(
+      const { proposalId } = await atomicSwapService.serviceCreate(
         req.walletId,
         proposal.partialTx.serialize(),
         serviceParams.password
@@ -205,7 +200,7 @@ async function signTx(req, res) {
   // TODO remove this when we create a method to sign inputs in the wallet facade
   storage.setStore(req.wallet.store);
   try {
-    const tx = assembleTransaction(partialTx, signatures, network);
+    const tx = atomicSwapService.assembleTransaction(partialTx, signatures, network);
 
     res.send({ success: true, txHex: tx.toHex() });
   } catch (err) {
@@ -237,7 +232,7 @@ async function signAndPush(req, res) {
   // TODO remove this when we create a method to sign inputs in the wallet facade
   storage.setStore(req.wallet.store);
   try {
-    const transaction = assembleTransaction(partialTx, sigs, network);
+    const transaction = atomicSwapService.assembleTransaction(partialTx, sigs, network);
 
     const sendTransaction = new SendTransaction({ transaction, network });
     const response = await sendTransaction.runFromMining();
@@ -352,7 +347,7 @@ async function unlockInputs(req, res) {
  * Fetches the list of proposals being listened to by this wallet on the Atomic Swap Service
  */
 async function listenedProposalList(req, res) {
-  const proposalMap = await getListenedProposals(req.walletId);
+  const proposalMap = await atomicSwapService.getListenedProposals(req.walletId);
 
   // Transform the map into an array of proposalIds;
   const list = [];
@@ -365,7 +360,7 @@ async function listenedProposalList(req, res) {
 
 async function deleteListenedProposal(req, res) {
   try {
-    await removeListenedProposal(req.walletId, req.params.proposalId);
+    await atomicSwapService.removeListenedProposal(req.walletId, req.params.proposalId);
     res.send({ success: true });
   } catch (e) {
     res.send({ success: false, error: e.message });

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -18,7 +18,8 @@ const {
 const {
   assembleTransaction,
   serviceCreate,
-  getListenedProposals
+  getListenedProposals,
+  removeListenedProposal,
 } = require('../../../services/atomic-swap.service');
 const { parametersValidation } = require('../../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../../lock');
@@ -362,6 +363,15 @@ async function listenedProposalList(req, res) {
   res.send(list);
 }
 
+async function deleteListenedProposal(req, res) {
+  try {
+    await removeListenedProposal(req.walletId, req.params.proposalId);
+    res.send({ success: true });
+  } catch (e) {
+    res.send({ success: false, error: e.message });
+  }
+}
+
 module.exports = {
   buildTxProposal,
   getInputData,
@@ -371,4 +381,5 @@ module.exports = {
   signTx,
   unlockInputs,
   listenedProposalList,
+  deleteListenedProposal,
 };

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -355,7 +355,7 @@ async function listenedProposalList(req, res) {
     list.push(proposal.id);
   });
 
-  res.send(list);
+  res.send({ success: true, proposals: list });
 }
 
 /**

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -136,6 +136,7 @@ async function buildTxProposal(req, res) {
     let createdProposalId;
     if (constants.SWAP_SERVICE_FEATURE_TOGGLE && serviceParams.is_new) {
       const { proposalId } = await serviceCreate(
+        req.walletId,
         proposal.partialTx.serialize(),
         serviceParams.password
       );

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -358,6 +358,9 @@ async function listenedProposalList(req, res) {
   res.send(list);
 }
 
+/**
+ * Deletes a listened proposal by proposalId
+ */
 async function deleteListenedProposal(req, res) {
   try {
     await atomicSwapService.removeListenedProposal(req.walletId, req.params.proposalId);

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -15,6 +15,7 @@ const { lock, lockTypes } = require('../../lock');
 const { cantSendTxErrorMessage, friendlyWalletState } = require('../../helpers/constants');
 const { mapTxReturn, prepareTxFunds } = require('../../helpers/tx.helper');
 const { initializedWallets } = require('../../services/wallets.service');
+const { removeAllWalletProposals } = require('../../services/atomic-swap.service');
 
 function getStatus(req, res) {
   const { wallet } = req;
@@ -558,12 +559,13 @@ async function createNft(req, res) {
   }
 }
 
-function stop(req, res) {
+async function stop(req, res) {
   // Stop wallet and remove from wallets object
   const { wallet } = req;
   wallet.stop();
 
   initializedWallets.delete(req.walletId);
+  await removeAllWalletProposals(req.walletId);
   res.send({ success: true });
 }
 

--- a/src/routes/wallet/atomic-swap/tx-proposal.routes.js
+++ b/src/routes/wallet/atomic-swap/tx-proposal.routes.js
@@ -21,6 +21,7 @@ const {
   unlockInputs,
   getLockedUTXOs,
   getInputData,
+  listenedProposalList,
 } = require('../../../controllers/wallet/atomic-swap/tx-proposal.controller');
 
 const txProposalRouter = Router({ mergeParams: true });
@@ -68,6 +69,11 @@ txProposalRouter.post(
   '/get-input-data',
   checkSchema(txHexSchema),
   getInputData,
+);
+
+txProposalRouter.get(
+  '/list',
+  listenedProposalList,
 );
 
 module.exports = txProposalRouter;

--- a/src/routes/wallet/atomic-swap/tx-proposal.routes.js
+++ b/src/routes/wallet/atomic-swap/tx-proposal.routes.js
@@ -22,6 +22,7 @@ const {
   getLockedUTXOs,
   getInputData,
   listenedProposalList,
+  deleteListenedProposal,
 } = require('../../../controllers/wallet/atomic-swap/tx-proposal.controller');
 
 const txProposalRouter = Router({ mergeParams: true });
@@ -74,6 +75,11 @@ txProposalRouter.post(
 txProposalRouter.get(
   '/list',
   listenedProposalList,
+);
+
+txProposalRouter.delete(
+  '/delete/:proposalId',
+  deleteListenedProposal,
 );
 
 module.exports = txProposalRouter;

--- a/src/services/atomic-swap.service.js
+++ b/src/services/atomic-swap.service.js
@@ -34,11 +34,12 @@ const assembleTransaction = (partialTx, signatures, network) => {
 
 /**
  * Creates the proposal on the Atomic Swap Service, handling errors that may occur on the process
+ * @param {string} walletId The initialized wallet identifier that created this proposal
  * @param {string} partialTx Serialized PartialTx
  * @param {string} password Password, length 3 or more
  * @returns {Promise<{ proposalId: string }>} Returns the proposal identifier created by the service
  */
-const serviceCreate = async (partialTx, password) => {
+const serviceCreate = async (walletId, partialTx, password) => {
   if (!partialTx) {
     throw new Error('Invalid PartialTx');
   }
@@ -51,6 +52,7 @@ const serviceCreate = async (partialTx, password) => {
     throw new Error('Unable to create the proposal on the Atomic Swap Service');
   }
 
+  await addListenedProposal(walletId, id, password);
   return { proposalId: id };
 };
 
@@ -64,7 +66,7 @@ const serviceCreate = async (partialTx, password) => {
 const addListenedProposal = async (walletId, proposalId, password) => {
   // Checking if this wallet map has been initialized already
   if (!walletListenedProposals.has(walletId)) {
-    walletListenedProposals[walletId] = new Map();
+    walletListenedProposals.set(walletId, new Map());
     // Will also open the websocket channel
   }
 

--- a/src/services/atomic-swap.service.js
+++ b/src/services/atomic-swap.service.js
@@ -9,7 +9,25 @@ const {
   PartialTxInputData,
   swapService,
 } = require('@hathor/wallet-lib');
-const { walletListenedProposals } = require('./wallets.service');
+
+/**
+ * @typedef TxProposalConfig
+ * @property {string} id Proposal identifier on the Atomic Swap Service
+ * @property {string} password Password to access it
+ */
+
+/**
+ * A map of all the proposals for a wallet.
+ * The keys are the proposal ids
+ * @typedef {Map<string,TxProposalConfig>} WalletListenedProposals
+ */
+
+/**
+ * A map of the initialized wallets and their listened proposals.
+ * The keys are the wallet-ids
+ * @type {Map<string,WalletListenedProposals>}
+ */
+const walletListenedProposals = new Map();
 
 /**
  * Assemble a transaction from the serialized partial tx and signatures
@@ -118,4 +136,5 @@ module.exports = {
   removeListenedProposal,
   getListenedProposals,
   removeAllWalletProposals,
+  walletListenedProposals,
 };

--- a/src/services/atomic-swap.service.js
+++ b/src/services/atomic-swap.service.js
@@ -85,12 +85,12 @@ const addListenedProposal = async (walletId, proposalId, password) => {
   // Checking if this wallet map has been initialized already
   if (!walletListenedProposals.has(walletId)) {
     walletListenedProposals.set(walletId, new Map());
-    // Will also open the websocket channel
+    // TODO: Will also open the websocket channel
   }
 
   const listenedProposals = walletListenedProposals.get(walletId);
   listenedProposals.set(proposalId, { id: proposalId, password });
-  // Will also add the proposalId to the Atomic Swap Service websocket channel
+  // TODO: Will also add the proposalId to the Atomic Swap Service websocket channel
 };
 
 /**
@@ -107,8 +107,8 @@ const removeListenedProposal = async (walletId, proposalId) => {
 
   const listenedProposals = walletListenedProposals.get(walletId);
   listenedProposals.delete(proposalId);
-  // Will also remove the proposalId from the Atomic Swap Service websocket channel
-  // If this was the last proposal to be removed, will also delete the channel itself
+  // TODO: Will also remove the proposalId from the Atomic Swap Service websocket channel
+  // TODO: If this was the last proposal to be removed, will also delete the channel itself
 };
 
 /**
@@ -126,7 +126,7 @@ const getListenedProposals = async walletId => walletListenedProposals.get(walle
 const removeAllWalletProposals = async walletId => {
   // Remove all of the listened proposals
   walletListenedProposals.delete(walletId);
-  // Will also close the websocket channel
+  // TODO: Will also close the websocket channel
 };
 
 module.exports = {

--- a/src/services/atomic-swap.service.js
+++ b/src/services/atomic-swap.service.js
@@ -71,7 +71,7 @@ const addListenedProposal = async (walletId, proposalId, password) => {
   }
 
   const listenedProposals = walletListenedProposals.get(walletId);
-  listenedProposals.set(proposalId, { proposalId, password });
+  listenedProposals.set(proposalId, { id: proposalId, password });
   // Will also add the proposalId to the Atomic Swap Service websocket channel
 };
 
@@ -94,6 +94,13 @@ const removeListenedProposal = async (walletId, proposalId) => {
 };
 
 /**
+ * Retrieves the map of proposals being listened by this wallet.
+ * @param walletId
+ * @return {Promise<Map<string, TxProposalConfig>>}
+ */
+const getListenedProposals = async walletId => walletListenedProposals.get(walletId) || new Map();
+
+/**
  * Removes the `listenedProposals` map for a wallet, if it exists
  * @param {string} walletId
  * @return {Promise<void>}
@@ -109,5 +116,6 @@ module.exports = {
   serviceCreate,
   addListenedProposal,
   removeListenedProposal,
+  getListenedProposals,
   removeAllWalletProposals,
 };

--- a/src/services/atomic-swap.service.js
+++ b/src/services/atomic-swap.service.js
@@ -9,6 +9,7 @@ const {
   PartialTxInputData,
   swapService,
 } = require('@hathor/wallet-lib');
+const { walletListenedProposals } = require('./wallets.service');
 
 /**
  * Assemble a transaction from the serialized partial tx and signatures
@@ -53,7 +54,58 @@ const serviceCreate = async (partialTx, password) => {
   return { proposalId: id };
 };
 
+/**
+ * Adds a new proposal to the `listenedProposals` map of a wallet.
+ * @param {string} walletId
+ * @param {string} proposalId
+ * @param {string} password
+ * @return {Promise<void>}
+ */
+const addListenedProposal = async (walletId, proposalId, password) => {
+  // Checking if this wallet map has been initialized already
+  if (!walletListenedProposals.has(walletId)) {
+    walletListenedProposals[walletId] = new Map();
+    // Will also open the websocket channel
+  }
+
+  const listenedProposals = walletListenedProposals.get(walletId);
+  listenedProposals.set(proposalId, { proposalId, password });
+  // Will also add the proposalId to the Atomic Swap Service websocket channel
+};
+
+/**
+ * Removes a proposal from the `listenedProposals` map of a wallet
+ * @param {string} walletId
+ * @param {string} proposalId
+ * @return {Promise<void>}
+ */
+const removeListenedProposal = async (walletId, proposalId) => {
+  // If this wallet map has not been initialized, just ignore the request
+  if (!walletListenedProposals.has(walletId)) {
+    return;
+  }
+
+  const listenedProposals = walletListenedProposals.get(walletId);
+  listenedProposals.delete(proposalId);
+  // Will also remove the proposalId from the Atomic Swap Service websocket channel
+  // If this was the last proposal to be removed, will also delete the channel itself
+};
+
+/**
+ * Removes the `listenedProposals` map for a wallet, if it exists
+ * @param {string} walletId
+ * @return {Promise<void>}
+ */
+const removeAllWalletProposals = async walletId => {
+  // Remove all of the listened proposals
+  walletListenedProposals.delete(walletId);
+  // Will also close the websocket channel
+};
+
 module.exports = {
   assembleTransaction,
   serviceCreate,
+  addListenedProposal,
+  removeListenedProposal,
+  removeAllWalletProposals,
 };

--- a/src/services/wallets.service.js
+++ b/src/services/wallets.service.js
@@ -6,26 +6,7 @@
  */
 
 const initializedWallets = new Map();
-/**
- * @typedef TxProposalConfig
- * @property {string} id Proposal identifier on the Atomic Swap Service
- * @property {string} password Password to access it
- */
-
-/**
- * A map of all the proposals for a wallet.
- * The keys are the proposal ids
- * @typedef {Map<string,TxProposalConfig>} WalletListenedProposals
- */
-
-/**
- * A map of the initialized wallets and their listened proposals.
- * The keys are the wallet-ids
- * @type {Map<string,WalletListenedProposals>}
- */
-const walletListenedProposals = new Map();
 
 module.exports = {
   initializedWallets,
-  walletListenedProposals,
 };

--- a/src/services/wallets.service.js
+++ b/src/services/wallets.service.js
@@ -6,7 +6,26 @@
  */
 
 const initializedWallets = new Map();
+/**
+ * @typedef TxProposalConfig
+ * @property {string} id Proposal identifier on the Atomic Swap Service
+ * @property {string} password Password to access it
+ */
+
+/**
+ * A map of all the proposals for a wallet.
+ * The keys are the proposal ids
+ * @typedef {Map<string,TxProposalConfig>} WalletListenedProposals
+ */
+
+/**
+ * A map of the initialized wallets and their listened proposals.
+ * The keys are the wallet-ids
+ * @type {Map<string,WalletListenedProposals>}
+ */
+const walletListenedProposals = new Map();
 
 module.exports = {
   initializedWallets,
+  walletListenedProposals,
 };


### PR DESCRIPTION
### Summary
Creates the infrastructure described on design HathorNetwork/rfcs#50 to keep track of the proposals being listened by a wallet, also adapting the existing `create` endpoint.

### Acceptance Criteria
- Implement the listened proposals structure
- The existing `create` route should add proposals to it
- Implement the `list` and `remove` endpoints

Note: the `fetch`, `register` and `update` endpoints will be implemented in separate PRs, since they involve interacting with the atomic swap service.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
