### PR TITLE
fix: 'success' field was missing in one response body

### DIFF
--- a/__tests__/address-info.test.js
+++ b/__tests__/address-info.test.js
@@ -17,7 +17,7 @@ describe('address-info api', () => {
       .query({ address: 'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.index).toBe(0);
   });
 
@@ -27,7 +27,7 @@ describe('address-info api', () => {
       .query({ address: 'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN', token: '01' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.index).toBe(0);
   });
 
@@ -37,6 +37,6 @@ describe('address-info api', () => {
       .query({ address: 'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQq3' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 });

--- a/__tests__/atomic-swap/get-my-signatures.test.js
+++ b/__tests__/atomic-swap/get-my-signatures.test.js
@@ -46,13 +46,13 @@ describe('get-my-signatures api', () => {
       .send({ partial_tx: 123 })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/get-my-signatures')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if an Error is thrown', async () => {

--- a/__tests__/atomic-swap/locked-utxos.test.js
+++ b/__tests__/atomic-swap/locked-utxos.test.js
@@ -63,14 +63,14 @@ describe('locked utxos api', () => {
       .set({ 'x-wallet-id': walletId });
     TestUtils.logger.debug('[atomic-swap:invalid-locked-params] response', { body: response.body });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/unlock')
       .set({ 'x-wallet-id': walletId });
     TestUtils.logger.debug('[atomic-swap:invalid-locked-params] response', { body: response.body });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should unlock utxos from a partial-tx', async () => {

--- a/__tests__/atomic-swap/p2sh.test.js
+++ b/__tests__/atomic-swap/p2sh.test.js
@@ -36,13 +36,13 @@ describe('atomic-swap with p2sh', () => {
       .send({ txHex: 123 })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/get-input-data')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should allow p2sh wallets to participate on an atomic-swap', async () => {

--- a/__tests__/atomic-swap/sign-and-push.test.js
+++ b/__tests__/atomic-swap/sign-and-push.test.js
@@ -48,14 +48,14 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ partial_tx: 123, signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // No partial_tx
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/sign-and-push')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // signatures are empty
     response = await TestUtils.request
@@ -63,7 +63,7 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ partial_tx: '123', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // signatures items are not string
     response = await TestUtils.request
@@ -71,7 +71,7 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ partial_tx: '123', signatures: ['1', 1] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if signatures is an invalid array', async () => {
@@ -80,14 +80,14 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ partial_tx: '1', signatures: [123] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/sign-and-push')
       .send({ partial_tx: '0123456789abcdef', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if an Error is thrown', async () => {

--- a/__tests__/atomic-swap/sign.test.js
+++ b/__tests__/atomic-swap/sign.test.js
@@ -48,14 +48,14 @@ describe('tx-proposal sign api', () => {
       .send({ partial_tx: 123, signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // No partial_tx
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/sign')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // signatures are empty
     response = await TestUtils.request
@@ -63,7 +63,7 @@ describe('tx-proposal sign api', () => {
       .send({ partial_tx: '123', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // signatures items are not string
     response = await TestUtils.request
@@ -71,7 +71,7 @@ describe('tx-proposal sign api', () => {
       .send({ partial_tx: '123', signatures: ['1', 1] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if signatures is an invalid array', async () => {
@@ -80,14 +80,14 @@ describe('tx-proposal sign api', () => {
       .send({ partial_tx: '1', signatures: [123] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal/sign')
       .send({ partial_tx: '0123456789abcdef', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if an Error is thrown', async () => {

--- a/__tests__/create-nft.test.js
+++ b/__tests__/create-nft.test.js
@@ -23,7 +23,7 @@ describe('create-nft api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.hash).toBeDefined();
   });
 
@@ -41,7 +41,7 @@ describe('create-nft api', () => {
         .send(token)
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -56,7 +56,7 @@ describe('create-nft api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should receive an error when trying to do concurrent create-token (lock/unlock behavior)', async () => {
@@ -83,7 +83,7 @@ describe('create-nft api', () => {
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 
   it('should not create an NFT with data size bigger than the max', async () => {
@@ -110,7 +110,7 @@ describe('create-nft api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeTruthy();
+    expect(response2.body.success).toBe(true);
     expect(response2.body.hash).toBeDefined();
   });
 });

--- a/__tests__/create-token.test.js
+++ b/__tests__/create-token.test.js
@@ -21,7 +21,7 @@ describe('create-token api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.hash).toBeDefined();
   });
 
@@ -35,7 +35,7 @@ describe('create-token api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.hash).toBeDefined();
   });
 
@@ -52,7 +52,7 @@ describe('create-token api', () => {
         .send(token)
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -66,7 +66,7 @@ describe('create-token api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should receive an error when trying to do concurrent create-token (lock/unlock behavior)', async () => {
@@ -91,7 +91,7 @@ describe('create-token api', () => {
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 
   // TODO: fix this test case crashing when mocking push_tx with status 400
@@ -107,6 +107,6 @@ describe('create-token api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 });

--- a/__tests__/decode.test.js
+++ b/__tests__/decode.test.js
@@ -25,14 +25,14 @@ describe('decode api', () => {
       .send({ txHex: 123 })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/decode')
       .send({ txHex: '0123g' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if txHex is an invalid transaction', async () => {
@@ -41,7 +41,7 @@ describe('decode api', () => {
       .send({ txHex: '0123456789abcdef' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the inputs and outputs of the original txHex', async () => {
@@ -63,7 +63,7 @@ describe('decode api', () => {
       .send({ txHex })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.tx).toBeDefined();
     // inputs
     expect(response.body.tx.inputs).toBeDefined();
@@ -113,14 +113,14 @@ describe('decode api', () => {
       .post('/wallet/decode')
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/decode')
       .send({ txHex, partial_tx: partialTx })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the inputs and outputs of a partialTx', async () => {

--- a/__tests__/integration/address-info.test.js
+++ b/__tests__/integration/address-info.test.js
@@ -61,7 +61,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(HATHOR_TOKEN_ID);
     expect(results.index).toBe(0);
     expect(results.total_amount_received).toBe(0);
@@ -80,7 +80,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(HATHOR_TOKEN_ID);
     expect(results.index).toBe(1);
     expect(results.total_amount_received).toBe(address1balance);
@@ -99,7 +99,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(HATHOR_TOKEN_ID);
     expect(results.index).toBe(0);
     expect(results.total_amount_received).toBeGreaterThan(0);
@@ -124,7 +124,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(HATHOR_TOKEN_ID);
     expect(results.index).toBe(0);
     expect(results.total_amount_received).toBe(15); // 10 from genesis, 5 from token creation change
@@ -146,7 +146,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(customTokenHash);
     expect(results.index).toBe(0);
     expect(results.total_amount_received).toBe(0);
@@ -168,7 +168,7 @@ describe('address-info routes', () => {
     expect(response.status).toBe(200);
 
     const results = response.body;
-    expect(results.success).toBeTruthy();
+    expect(results.success).toBe(true);
     expect(results.token).toBe(customTokenHash);
     expect(results.index).toBe(1);
     expect(results.total_amount_received).toBe(500);

--- a/__tests__/integration/readonly-wallet.test.js
+++ b/__tests__/integration/readonly-wallet.test.js
@@ -39,7 +39,7 @@ describe('Readonly wallet', () => {
       });
 
     expect(response.status).toEqual(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     try {
       // Wait until the wallet has actually started
       await TestUtils.poolUntilWalletReady(walletId);
@@ -71,7 +71,7 @@ describe('Readonly wallet', () => {
       });
     loggers.test.insertLineToLog('readonly[multisig]: get address', { body: response.body });
     expect(response.status).toEqual(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     try {
       // Wait until the wallet has actually started
       await TestUtils.poolUntilWalletReady(walletId);
@@ -101,7 +101,7 @@ describe('Readonly wallet', () => {
         precalculatedAddresses: addresses,
       });
     expect(response.status).toEqual(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     try {
       // Wait until the wallet has actually started
       await TestUtils.poolUntilWalletReady(walletId);

--- a/__tests__/melt-tokens.test.js
+++ b/__tests__/melt-tokens.test.js
@@ -52,7 +52,7 @@ describe('melt-tokens api', () => {
         .send(token)
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -66,7 +66,7 @@ describe('melt-tokens api', () => {
       .send(token)
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not melt less than 1 token', async () => {
@@ -79,7 +79,7 @@ describe('melt-tokens api', () => {
       .send(token)
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not melt more tokens than total amount', async () => {
@@ -92,7 +92,7 @@ describe('melt-tokens api', () => {
       .send(token)
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it.skip('should melt all tokens and return HTR as change', async () => {
@@ -105,7 +105,7 @@ describe('melt-tokens api', () => {
       .send(token)
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // Mimic the full node wallet:address_history message
     TestUtils.socket.send(JSON.stringify(wsFixtures.melt));
@@ -148,6 +148,6 @@ describe('melt-tokens api', () => {
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 });

--- a/__tests__/mint-tokens.test.js
+++ b/__tests__/mint-tokens.test.js
@@ -47,7 +47,7 @@ describe('mint-tokens api', () => {
         .send(token)
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -71,6 +71,6 @@ describe('mint-tokens api', () => {
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 });

--- a/__tests__/multisig-pubkey.test.js
+++ b/__tests__/multisig-pubkey.test.js
@@ -6,7 +6,7 @@ describe('multisig-pubkey api', () => {
       .post('/multisig-pubkey')
       .send({});
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not return the xpubkey with an invalid seedKey', async () => {
@@ -14,7 +14,7 @@ describe('multisig-pubkey api', () => {
       .post('/multisig-pubkey')
       .send({ seedKey: '123' });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the pubkey of a configured seed', async () => {
@@ -22,7 +22,7 @@ describe('multisig-pubkey api', () => {
       .post('/multisig-pubkey')
       .send({ seedKey: TestUtils.seedKey });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.xpubkey).toBe(TestUtils.multisigXpub);
   });
 });

--- a/__tests__/p2sh/tx-proposal-create.test.js
+++ b/__tests__/p2sh/tx-proposal-create.test.js
@@ -26,7 +26,7 @@ describe('create tx-proposal api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.txHex).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     const tx = hathorLib.helpersUtils.createTxFromHex(response.body.txHex, new hathorLib.Network('testnet'));
     expect(tx.outputs.map(o => o.decodedScript.address.base58))
       .toEqual(expect.arrayContaining(['WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc', 'wcUZ6J7t2B1s8bqRYiyuZAftcdCGRSiiau']));
@@ -42,7 +42,7 @@ describe('create tx-proposal api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.txHex).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     const tx = hathorLib.helpersUtils.createTxFromHex(response.body.txHex, new hathorLib.Network('testnet'));
     expect(tx.outputs.map(o => o.decodedScript.address.base58))
       .toEqual(expect.arrayContaining(['WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc']));
@@ -62,7 +62,7 @@ describe('create tx-proposal api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.txHex).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept transactions without address or value', async () => {
@@ -73,7 +73,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal')
@@ -82,7 +82,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept transactions with 0 value', async () => {
@@ -93,7 +93,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should accept a custom token transaction', async () => {
@@ -105,7 +105,7 @@ describe('create tx-proposal api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.txHex).toBeTruthy();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a custom token transaction without funds to cover it', async () => {
@@ -120,7 +120,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should accept a transaction with a change_address that does belong to the wallet', async () => {
@@ -132,7 +132,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a transaction with a change_address that does not belong to the wallet', async () => {
@@ -144,6 +144,6 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 });

--- a/__tests__/p2sh/tx-proposal-get-my-signatures.test.js
+++ b/__tests__/p2sh/tx-proposal-get-my-signatures.test.js
@@ -23,14 +23,14 @@ describe('get-my-signatures api', () => {
       .send({ txHex: 123 })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal/get-my-signatures')
       .send({ txHex: '0123g' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if txHex is an invalid transaction', async () => {
@@ -39,7 +39,7 @@ describe('get-my-signatures api', () => {
       .send({ txHex: '0123456789abcdef' })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the signatures for the inputs we own on the transaction', async () => {
@@ -61,7 +61,7 @@ describe('get-my-signatures api', () => {
       .send({ txHex })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     expect(response.body.signatures).toBeDefined();
     expect(response.body.signatures.split('|').length).toBe(2);
   });

--- a/__tests__/p2sh/tx-proposal-sign-and-push.test.js
+++ b/__tests__/p2sh/tx-proposal-sign-and-push.test.js
@@ -23,14 +23,14 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ txHex: 123, signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal/sign-and-push')
       .send({ txHex: '0123g', signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if txHex is an invalid transaction', async () => {
@@ -39,7 +39,7 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ txHex: '0123456789abcdef', signatures: ['123'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if signatures is an invalid array', async () => {
@@ -48,14 +48,14 @@ describe('tx-proposal sign-and-push api', () => {
       .send({ txHex: '0123456789abcdef', signatures: [123] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal/sign-and-push')
       .send({ txHex: '0123456789abcdef', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the signatures for the inputs we own on the transaction', async () => {
@@ -83,6 +83,6 @@ describe('tx-proposal sign-and-push api', () => {
       .post('/wallet/p2sh/tx-proposal/sign-and-push')
       .send({ txHex, signatures: [signature, signature, signature] })
       .set({ 'x-wallet-id': walletId });
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 });

--- a/__tests__/p2sh/tx-proposal-sign.test.js
+++ b/__tests__/p2sh/tx-proposal-sign.test.js
@@ -23,14 +23,14 @@ describe('tx-proposal sign api', () => {
       .send({ txHex: 123, signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal/sign')
       .send({ txHex: '0123g', signatures: ['1'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if txHex is an invalid transaction', async () => {
@@ -39,7 +39,7 @@ describe('tx-proposal sign api', () => {
       .send({ txHex: '0123456789abcdef', signatures: ['123'] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should fail if signatures is an invalid array', async () => {
@@ -48,14 +48,14 @@ describe('tx-proposal sign api', () => {
       .send({ txHex: '0123456789abcdef', signatures: [123] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/p2sh/tx-proposal/sign')
       .send({ txHex: '0123456789abcdef', signatures: [] })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return the signatures for the inputs we own on the transaction', async () => {
@@ -83,6 +83,6 @@ describe('tx-proposal sign api', () => {
       .post('/wallet/p2sh/tx-proposal/sign')
       .send({ txHex, signatures: [signature, signature, signature] })
       .set({ 'x-wallet-id': walletId });
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 });

--- a/__tests__/push-tx-hex.test.js
+++ b/__tests__/push-tx-hex.test.js
@@ -32,7 +32,7 @@ describe('push tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return error from wallet-lib method errors', async () => {

--- a/__tests__/send-tx.test.js
+++ b/__tests__/send-tx.test.js
@@ -23,7 +23,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should return 200 with selecting inputs by query with custom tokens', async () => {
@@ -39,7 +39,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should return 200 with a valid body', async () => {
@@ -51,7 +51,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should return 200 with a valid body selecting inputs', async () => {
@@ -64,7 +64,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should accept value as string', async () => {
@@ -79,7 +79,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept transactions without address or value', async () => {
@@ -90,7 +90,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/send-tx')
@@ -99,7 +99,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept transactions with 0 value', async () => {
@@ -110,7 +110,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should receive an error when trying to do concurrent transactions (lock/unlock behavior)', async () => {
@@ -131,7 +131,7 @@ describe('send-tx api', () => {
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeTruthy();
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 
   it('should accept a custom token transaction', async () => {
@@ -149,7 +149,7 @@ describe('send-tx api', () => {
     TestUtils.logger.debug('send-tx[custom token] response', { body: response.body });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeTruthy();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should accept a custom token transaction (token as string)', async () => {
@@ -162,7 +162,7 @@ describe('send-tx api', () => {
     TestUtils.logger.debug('send-tx[custom token as string] response', { body: response.body });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeTruthy();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a custom token transaction without funds to cover it', async () => {
@@ -178,7 +178,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept a custom token transaction without funds to cover it (filter query)', async () => {
@@ -207,7 +207,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should accept a transaction with a change_address that does belong to the wallet', async () => {
@@ -219,7 +219,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a custom token transaction without all token properties', async () => {
@@ -238,7 +238,7 @@ describe('send-tx api', () => {
         })
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -251,7 +251,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept a transaction incomplete output data', async () => {
@@ -283,7 +283,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeTruthy();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should accept a transaction with data output and p2pkh output', async () => {
@@ -298,7 +298,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeTruthy();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a transaction with data size bigger than the maximum', async () => {
@@ -320,7 +320,7 @@ describe('send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response2.status).toBe(200);
     expect(response2.body.hash).toBeTruthy();
-    expect(response2.body.success).toBeTruthy();
+    expect(response2.body.success).toBe(true);
   });
 
   it('should log errors on send-tx when debug=true on req.body', async () => {
@@ -335,7 +335,7 @@ describe('send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
     expect(response.body.error).toEqual('Boom!');
     spy.mockRestore();
   });

--- a/__tests__/simple-send-tx.test.js
+++ b/__tests__/simple-send-tx.test.js
@@ -21,7 +21,7 @@ describe('simple-send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should accept value as string', async () => {
@@ -34,7 +34,7 @@ describe('simple-send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a transaction with value 0', async () => {
@@ -46,7 +46,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.succes).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept transactions without address or value', async () => {
@@ -57,7 +57,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.succes).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/simple-send-tx')
@@ -66,7 +66,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.succes).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should receive an error when trying to do concurrent transactions (lock/unlock behavior)', async () => {
@@ -88,9 +88,9 @@ describe('simple-send-tx api', () => {
     const [response1, response2] = await Promise.all([promise1, promise2]);
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeDefined();
-    expect(response1.body.success).toBeTruthy();
+    expect(response1.body.success).toBe(true);
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 
   it('should receive an error when trying to simple-send-tx and create-token concurrently (lock/unlock behavior)', async () => {
@@ -113,9 +113,9 @@ describe('simple-send-tx api', () => {
     const [response1, response2] = await Promise.all([promise1, promise2]);
     expect(response1.status).toBe(200);
     expect(response1.body.hash).toBeDefined();
-    expect(response1.body.success).toBeTruthy();
+    expect(response1.body.success).toBe(true);
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
   });
 
   it('should accept a custom token transaction', async () => {
@@ -133,7 +133,7 @@ describe('simple-send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should accept a custom token transaction (token as string)', async () => {
@@ -147,7 +147,7 @@ describe('simple-send-tx api', () => {
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
     expect(response.body.hash).toBeDefined();
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a custom token transaction without funds to cover it', async () => {
@@ -164,7 +164,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept a custom token transaction without funds to cover it (token as string)', async () => {
@@ -177,7 +177,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should accept a transaction with a change_address that does belong to the wallet', async () => {
@@ -190,7 +190,7 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
   });
 
   it('should not accept a custom token transaction without all token properties', async () => {
@@ -210,7 +210,7 @@ describe('simple-send-tx api', () => {
         })
         .set({ 'x-wallet-id': walletId });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBeFalsy();
+      expect(response.body.success).toBe(false);
     });
   });
 
@@ -224,6 +224,6 @@ describe('simple-send-tx api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 });

--- a/__tests__/start.test.js
+++ b/__tests__/start.test.js
@@ -20,7 +20,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: '123', 'wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not start a wallet without a seedKey', async () => {
@@ -28,7 +28,7 @@ describe('start api', () => {
       .post('/start')
       .send({ 'wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not start a wallet without a wallet-id', async () => {
@@ -36,7 +36,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not start two wallets with same wallet-id', async () => {
@@ -45,14 +45,14 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
 
     // Second start
     const response2 = await TestUtils.request
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
     expect(response2.body.errorCode).toEqual('WALLET_ALREADY_STARTED');
   });
 
@@ -82,7 +82,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeTruthy();
+    expect(response.body.success).toBe(true);
     await TestUtils.waitReady({ walletId });
 
     response = await TestUtils.request
@@ -107,7 +107,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId, multisig: true });
     expect(response1.status).toBe(200);
-    expect(response1.body.success).toBeTruthy();
+    expect(response1.body.success).toBe(true);
     await TestUtils.waitReady({ walletId });
 
     const response2 = await TestUtils.request
@@ -128,7 +128,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId, multisig: true });
     expect(response1.status).toBe(200);
-    expect(response1.body.success).toBeFalsy();
+    expect(response1.body.success).toBe(false);
 
     global.config.multisig = TestUtils.multisigData;
     global.config.multisig[TestUtils.seedKey].total = 6;
@@ -137,7 +137,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId, multisig: true });
     expect(response2.status).toBe(200);
-    expect(response2.body.success).toBeFalsy();
+    expect(response2.body.success).toBe(false);
 
     global.config.multisig[TestUtils.seedKey].total = 5;
     global.config.multisig[TestUtils.seedKey].numSignatures = 6;
@@ -146,7 +146,7 @@ describe('start api', () => {
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId, multisig: true });
     expect(response3.status).toBe(200);
-    expect(response3.body.success).toBeFalsy();
+    expect(response3.body.success).toBe(false);
 
     global.config.multisig = {};
   });

--- a/__tests__/transaction.test.js
+++ b/__tests__/transaction.test.js
@@ -33,7 +33,7 @@ describe('transaction api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return 400 for missing parameter id', async () => {
@@ -77,7 +77,7 @@ describe('transaction blocks confirmation number', () => {
       })
       .set({ 'x-wallet-id': walletIdConfirmation });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return 400 for missing parameter id', async () => {

--- a/__tests__/tx-proposal/add-signatures.test.js
+++ b/__tests__/tx-proposal/add-signatures.test.js
@@ -24,7 +24,7 @@ describe('add signatures api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept invalid signatures', async () => {
@@ -38,7 +38,7 @@ describe('add signatures api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/tx-proposal/add-signatures')
@@ -50,7 +50,7 @@ describe('add signatures api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should add signatures to the transaction', async () => {

--- a/__tests__/tx-proposal/build-tx.test.js
+++ b/__tests__/tx-proposal/build-tx.test.js
@@ -41,7 +41,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/tx-proposal')
@@ -50,7 +50,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept transactions with 0 value', async () => {
@@ -61,7 +61,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept tx inputs without index or hash', async () => {
@@ -73,7 +73,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     response = await TestUtils.request
       .post('/wallet/tx-proposal')
@@ -83,7 +83,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept wrong custom tokens', async () => {
@@ -95,7 +95,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // Hex value but invalid token uid (!== 64 chars)
     response = await TestUtils.request
@@ -105,7 +105,7 @@ describe('create tx-proposal api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept incomplete data outputs', async () => {

--- a/__tests__/tx-proposal/get-wallet-inputs.test.js
+++ b/__tests__/tx-proposal/get-wallet-inputs.test.js
@@ -23,7 +23,7 @@ describe('get wallet inputs api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should return error from wallet-lib method errors', async () => {

--- a/__tests__/tx-proposal/getInputData.test.js
+++ b/__tests__/tx-proposal/getInputData.test.js
@@ -31,7 +31,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // P2SH
     response = await TestUtils.request
@@ -42,7 +42,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept invalid indexes', async () => {
@@ -55,7 +55,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // missing index
     response = await TestUtils.request
@@ -65,7 +65,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // P2SH
     response = await TestUtils.request
@@ -76,7 +76,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
 
     // missing index
     response = await TestUtils.request
@@ -86,7 +86,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(400);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
   });
 
   it('should not accept P2SH inputs from a P2PKH wallet', async () => {
@@ -98,7 +98,7 @@ describe('Get input-data api', () => {
       })
       .set({ 'x-wallet-id': walletId });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
     expect(response.body.error).toEqual('wallet is not MultiSig');
   });
 
@@ -114,7 +114,7 @@ describe('Get input-data api', () => {
       .set({ 'x-wallet-id': walletIdMultisig });
     TestUtils.logger.debug('input-data[reject unknown signers]', { body: response.body });
     expect(response.status).toBe(200);
-    expect(response.body.success).toBeFalsy();
+    expect(response.body.success).toBe(false);
     expect(response.body.error).toEqual('signature from unknown signer');
   });
 

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -68,6 +68,7 @@ function start(req, res) {
     // it must first stop the old wallet and then start the new
     console.error('Error starting wallet because this wallet-id is already in use. You must stop the wallet first.');
     res.send({
+      success: false,
       message: `Failed to start wallet with wallet id ${walletID}`,
       errorCode: API_ERROR_CODES.WALLET_ALREADY_STARTED,
     });


### PR DESCRIPTION
closes: https://github.com/HathorNetwork/on-call-incidents/issues/99

### Acceptance Criteria
- We should have the 'success' field in the response body of the /start API, when someone tries to start an already started wallet id. It was removed in past PRs.

- We should make sure our tests will fail in case we remove the `success` field again in some response. Since we were using `toBeFalsy` and `toBeTruthy` to test the API response, the error wouldn't be caught by the tests (because `undefined` is falsy)


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
