### PR TITLE
feat: add parameter to create token and create nft endpoints to set authority addresses

### DIFF
--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants, network } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
@@ -247,23 +247,23 @@ describe('create-nft routes', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address1);
 
     done();
   });
 
-  it('Create token using external mint/melt address', async () => {
-    const address2_0 = await wallet2.getAddressAt(0);
-    const address2_1 = await wallet2.getAddressAt(1);
+  it('Create token using external mint/melt address', async done => {
+    const address2idx0 = await wallet2.getAddressAt(0);
+    const address2idx1 = await wallet2.getAddressAt(1);
 
     // External address for mint won't be successful
     const response = await TestUtils.request
@@ -272,7 +272,7 @@ describe('create-nft routes', () => {
         ...nftData,
         amount: 1,
         create_mint: true,
-        mint_authority_address: address2_0,
+        mint_authority_address: address2idx0,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -285,7 +285,7 @@ describe('create-nft routes', () => {
         ...nftData,
         amount: 1,
         create_melt: true,
-        melt_authority_address: address2_1,
+        melt_authority_address: address2idx1,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -298,10 +298,10 @@ describe('create-nft routes', () => {
         ...nftData,
         amount: 1,
         create_mint: true,
-        mint_authority_address: address2_0,
+        mint_authority_address: address2idx0,
         allow_external_mint_authority_address: true,
         create_melt: true,
-        melt_authority_address: address2_1,
+        melt_authority_address: address2idx1,
         allow_external_melt_authority_address: true,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
@@ -320,16 +320,16 @@ describe('create-nft routes', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(network);
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address2_0);
+    expect(mintP2pkh.address.base58).toEqual(address2idx0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(network);
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address2_1);
+    expect(meltP2pkh.address.base58).toEqual(address2idx1);
 
     done();
   });

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants, network } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
@@ -218,7 +218,6 @@ describe('create-nft routes', () => {
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MINT)).toBeTruthy();
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MELT)).toBeTruthy();
   });
-
   it('should create the NFT and send authority outputs to the correct address', async done => {
     // By default, will mint tokens into the next unused address
     const address0 = await wallet1.getAddressAt(0);
@@ -237,7 +236,6 @@ describe('create-nft routes', () => {
 
     const transaction = response.body;
     expect(transaction.success).toBe(true);
-    await TestUtils.pauseForWsUpdate();
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
@@ -247,21 +245,21 @@ describe('create-nft routes', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(network);
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(network);
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address1);
 
     done();
   });
 
-  it('Create token using external mint/melt address', async done => {
+  it('Create nft using external mint/melt address', async done => {
     const address2idx0 = await wallet2.getAddressAt(0);
     const address2idx1 = await wallet2.getAddressAt(1);
 
@@ -276,7 +274,7 @@ describe('create-nft routes', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.success).toBe(false);
+    expect(response.body.success).toBe(false);
 
     // External address for melt won't be successful
     const response2 = await TestUtils.request
@@ -289,7 +287,7 @@ describe('create-nft routes', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response2.success).toBe(false);
+    expect(response2.body.success).toBe(false);
 
     // External address for both authorities will succeed with parameter allowing it
     const response3 = await TestUtils.request
@@ -306,11 +304,9 @@ describe('create-nft routes', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response3.success).toBe(true);
+    expect(response3.body.success).toBe(true);
 
-    const transaction = response.body;
-    expect(transaction.success).toBe(true);
-    await TestUtils.pauseForWsUpdate();
+    const transaction = response3.body;
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
@@ -320,14 +316,14 @@ describe('create-nft routes', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(network);
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address2idx0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(network);
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address2idx1);
 

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -218,7 +218,9 @@ describe('create-nft routes', () => {
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MINT)).toBeTruthy();
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MELT)).toBeTruthy();
   });
+
   it('should create the NFT and send authority outputs to the correct address', async done => {
+    await TestUtils.pauseForWsUpdate();
     // By default, will mint tokens into the next unused address
     const address0 = await wallet1.getAddressAt(0);
     const address1 = await wallet1.getAddressAt(1);
@@ -260,6 +262,7 @@ describe('create-nft routes', () => {
   });
 
   it('Create nft using external mint/melt address', async done => {
+    await TestUtils.pauseForWsUpdate();
     const address2idx0 = await wallet2.getAddressAt(0);
     const address2idx1 = await wallet2.getAddressAt(1);
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants, network } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
 import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
@@ -31,7 +31,6 @@ describe('create token', () => {
   });
 
   // Testing failures first, that do not cause side-effects on the blockchain
-
   it('should reject missing name parameter', async done => {
     const response = await TestUtils.request
       .post('/wallet/create-token')
@@ -382,7 +381,6 @@ describe('create token', () => {
 
     const transaction = response.body;
     expect(transaction.success).toBe(true);
-    await TestUtils.pauseForWsUpdate();
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
@@ -392,14 +390,14 @@ describe('create token', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(network);
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(network);
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address1);
 
@@ -422,7 +420,7 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response.success).toBe(false);
+    expect(response.body.success).toBe(false);
 
     // External address for melt won't be successful
     const response2 = await TestUtils.request
@@ -436,7 +434,7 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response2.success).toBe(false);
+    expect(response2.body.success).toBe(false);
 
     // External address for both authorities will succeed with parameter allowing it
     const response3 = await TestUtils.request
@@ -454,11 +452,10 @@ describe('create token', () => {
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
-    expect(response3.success).toBe(true);
+    expect(response3.body.success).toBe(true);
 
-    const transaction = response.body;
+    const transaction = response3.body;
     expect(transaction.success).toBe(true);
-    await TestUtils.pauseForWsUpdate();
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
@@ -468,14 +465,14 @@ describe('create token', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(network);
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address2idx0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(network);
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address2idx1);
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants } from '@hathor/wallet-lib';
 import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
@@ -21,6 +21,7 @@ describe('create token', () => {
     await WalletHelper.startMultipleWalletsForTest([wallet1, wallet2]);
     await wallet1.injectFunds(10, 0);
     await wallet1.injectFunds(10, 1);
+    await wallet1.injectFunds(10, 2);
     await wallet2.injectFunds(10, 0);
   });
 
@@ -279,6 +280,205 @@ describe('create token', () => {
     expect(addr4.total_amount_received).toBe(htrChange);
     const addr4C = await wallet2.getAddressInfo(4, transaction.hash);
     expect(addr4C.total_amount_available).toBe(200);
+    done();
+  });
+
+  it('should create token with only mint authority', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: true
+        create_melt: false
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+    const tx = response.body;
+
+    expect(tx.hash).toBeDefined();
+
+    // Validating authority tokens
+    const authorityOutputs = tx.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs.length).toBe(1);
+    expect(authorityOutputs[0].value).toBe(constants.TOKEN_MINT_MASK);
+  });
+
+  it('should create token with only melt authority', async () => {
+    // Since no pause was necessary on the last test, we will add one here to improve stability
+    await TestUtils.pauseForWsUpdate();
+
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: false
+        create_melt: true
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+    const tx = response.body;
+
+    expect(tx.hash).toBeDefined();
+
+    // Validating authority tokens
+    const authorityOutputs = tx.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs.length).toBe(1);
+    expect(authorityOutputs[0].value).toBe(constants.TOKEN_MELT_MASK);
+  });
+
+  it('should create token with mint and melt authorities', async () => {
+    await TestUtils.pauseForWsUpdate();
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: true
+        create_melt: true
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(true);
+    const tx = response.body;
+
+    expect(tx.hash).toBeDefined();
+
+    // Validating authority tokens
+    const authorityOutputs = tx.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs.length).toBe(2);
+    expect(authorityOutputs.find(o => o.value === constants.TOKEN_MINT_MASK)).toBeTruthy();
+    expect(authorityOutputs.find(o => o.value === constants.TOKEN_MELT_MASK)).toBeTruthy();
+  });
+
+  it('should create the token and send authority outputs to the correct address', async done => {
+    // By default, will mint tokens into the next unused address
+    const address0 = await wallet1.getAddressAt(0);
+    const address1 = await wallet1.getAddressAt(1);
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: true,
+        mint_authority_address: address0,
+        create_melt: true,
+        melt_authority_address: address1,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    const transaction = response.body;
+    expect(transaction.success).toBe(true);
+    await TestUtils.pauseForWsUpdate();
+
+    // Validating a new mint authority was created
+    const authorityOutputs = transaction.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs).toHaveLength(2);
+    const mintOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MINT_MASK
+    );
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    // Validate that the mint output was sent to the correct address
+    expect(mintP2pkh.address.base58).toEqual(address0);
+
+    const meltOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MELT_MASK
+    );
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    // Validate that the melt output was sent to the correct address
+    expect(meltP2pkh.address.base58).toEqual(address1);
+
+    done();
+  });
+
+  it('Create token using external mint/melt address', async () => {
+    const address2_0 = await wallet2.getAddressAt(0);
+    const address2_1 = await wallet2.getAddressAt(1);
+
+    // External address for mint won't be successful
+    const response = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: true,
+        mint_authority_address: address2_0,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.success).toBe(false);
+
+    // External address for melt won't be successful
+    const response2 = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_melt: true,
+        melt_authority_address: address2_1,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response2.success).toBe(false);
+
+    // External address for both authorities will succeed with parameter allowing it
+    const response3 = await TestUtils.request
+      .post('/wallet/create-token')
+      .send({
+        name: 'Token X',
+        symbol: 'TKX',
+        amount: 100,
+        create_mint: true,
+        mint_authority_address: address2_0,
+        allow_external_mint_authority_address: true,
+        create_melt: true,
+        melt_authority_address: address2_1,
+        allow_external_melt_authority_address: true,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response3.success).toBe(true);
+
+    const transaction = response.body;
+    expect(transaction.success).toBe(true);
+    await TestUtils.pauseForWsUpdate();
+
+    // Validating a new mint authority was created
+    const authorityOutputs = transaction.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs).toHaveLength(2);
+    const mintOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MINT_MASK
+    );
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    // Validate that the mint output was sent to the correct address
+    expect(mintP2pkh.address.base58).toEqual(address2_0);
+
+    const meltOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MELT_MASK
+    );
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    // Validate that the melt output was sent to the correct address
+    expect(meltP2pkh.address.base58).toEqual(address2_1);
+
     done();
   });
 });

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -152,7 +152,7 @@ describe('create token', () => {
       .send({
         name: tokenA.name,
         symbol: tokenA.symbol,
-        amount: 3000
+        amount: 4000
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants, network } from '@hathor/wallet-lib';
 import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
@@ -290,7 +290,7 @@ describe('create token', () => {
         name: 'Token X',
         symbol: 'TKX',
         amount: 100,
-        create_mint: true
+        create_mint: true,
         create_melt: false
       })
       .set({ 'x-wallet-id': wallet1.walletId });
@@ -318,7 +318,7 @@ describe('create token', () => {
         name: 'Token X',
         symbol: 'TKX',
         amount: 100,
-        create_mint: false
+        create_mint: false,
         create_melt: true
       })
       .set({ 'x-wallet-id': wallet1.walletId });
@@ -344,7 +344,7 @@ describe('create token', () => {
         name: 'Token X',
         symbol: 'TKX',
         amount: 100,
-        create_mint: true
+        create_mint: true,
         create_melt: true
       })
       .set({ 'x-wallet-id': wallet1.walletId });
@@ -392,23 +392,23 @@ describe('create token', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(network);
     // Validate that the mint output was sent to the correct address
     expect(mintP2pkh.address.base58).toEqual(address0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(network);
     // Validate that the melt output was sent to the correct address
     expect(meltP2pkh.address.base58).toEqual(address1);
 
     done();
   });
 
-  it('Create token using external mint/melt address', async () => {
-    const address2_0 = await wallet2.getAddressAt(0);
-    const address2_1 = await wallet2.getAddressAt(1);
+  it('Create token using external mint/melt address', async done => {
+    const address2idx0 = await wallet2.getAddressAt(0);
+    const address2idx1 = await wallet2.getAddressAt(1);
 
     // External address for mint won't be successful
     const response = await TestUtils.request
@@ -418,7 +418,7 @@ describe('create token', () => {
         symbol: 'TKX',
         amount: 100,
         create_mint: true,
-        mint_authority_address: address2_0,
+        mint_authority_address: address2idx0,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -432,7 +432,7 @@ describe('create token', () => {
         symbol: 'TKX',
         amount: 100,
         create_melt: true,
-        melt_authority_address: address2_1,
+        melt_authority_address: address2idx1,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
 
@@ -446,10 +446,10 @@ describe('create token', () => {
         symbol: 'TKX',
         amount: 100,
         create_mint: true,
-        mint_authority_address: address2_0,
+        mint_authority_address: address2idx0,
         allow_external_mint_authority_address: true,
         create_melt: true,
-        melt_authority_address: address2_1,
+        melt_authority_address: address2idx1,
         allow_external_melt_authority_address: true,
       })
       .set({ 'x-wallet-id': wallet1.walletId });
@@ -468,16 +468,16 @@ describe('create token', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(network);
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address2_0);
+    expect(mintP2pkh.address.base58).toEqual(address2idx0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === constants.TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(network);
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address2_1);
+    expect(meltP2pkh.address.base58).toEqual(address2idx1);
 
     done();
   });

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -202,7 +202,7 @@ describe('create token', () => {
 
     const htrBalance = await wallet1.getBalance();
     const tkaBalance = await wallet1.getBalance(response.body.hash);
-    expect(htrBalance.available).toBe(19); // The initial 20 minus 1
+    expect(htrBalance.available).toBe(29); // The initial 30 minus 1
     expect(tkaBalance.available).toBe(100); // The newly minted TKA tokens
     done();
   });
@@ -363,6 +363,8 @@ describe('create token', () => {
   });
 
   it('should create the token and send authority outputs to the correct address', async done => {
+    // Since no pause was necessary on the last test, we will add one here to improve stability
+    await TestUtils.pauseForWsUpdate();
     // By default, will mint tokens into the next unused address
     const address0 = await wallet1.getAddressAt(0);
     const address1 = await wallet1.getAddressAt(1);
@@ -405,6 +407,8 @@ describe('create token', () => {
   });
 
   it('Create token using external mint/melt address', async done => {
+    // Since no pause was necessary on the last test, we will add one here to improve stability
+    await TestUtils.pauseForWsUpdate();
     const address2idx0 = await wallet2.getAddressAt(0);
     const address2idx1 = await wallet2.getAddressAt(1);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,9 +1197,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.46.0.tgz",
-      "integrity": "sha512-mM27on+Dj3lWlpvdh5W0XEJ9arCbDibpJqV/j7dI9PRFE/NVoVJ+r9DAvyv1ZBCPgYq3RwFZgoRzT1PTZX9Tlg==",
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.47.0.tgz",
+      "integrity": "sha512-8StKGC22UkCebJ75TKwNsGH0Dh4qidPmJ2oTyolsks9oxuVmZ0wo69Muvd7qQi1nbx1RxQJzW0eCNV3YGvw+ZQ==",
       "requires": {
         "axios": "^0.21.4",
         "bitcore-lib": "^8.25.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/node": "^7.13.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/preset-env": "^7.13.5",
-    "@hathor/wallet-lib": "^0.46.0",
+    "@hathor/wallet-lib": "^0.47.0",
     "express": "^4.17.1",
     "express-validator": "^6.10.0",
     "lodash": "^4.17.11",

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -2224,6 +2224,30 @@ const apiDoc = {
                     type: 'string',
                     description: 'Optional address to send the change amount.'
                   },
+                  create_mint: {
+                    type: 'boolean',
+                    description: 'If should create mint authority for the created token. Default is true.'
+                  },
+                  mint_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the mint authority output created.'
+                  },
+                  allow_external_mint_authority_address: {
+                    type: 'boolean',
+                    description: 'If the mint authority address is allowed to be from another wallet. Default is false.'
+                  },
+                  create_melt: {
+                    type: 'boolean',
+                    description: 'If should create melt authority for the created token. Default is true.'
+                  },
+                  melt_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the melt authority output created.'
+                  },
+                  allow_external_melt_authority_address: {
+                    type: 'boolean',
+                    description: 'If the melt authority address is allowed to be from another wallet. Default is false.'
+                  },
                 }
               },
               examples: {
@@ -2516,9 +2540,25 @@ const apiDoc = {
                     type: 'boolean',
                     description: 'If should create mint authority for the created NFT. Default is false.'
                   },
+                  mint_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the mint authority output created.'
+                  },
+                  allow_external_mint_authority_address: {
+                    type: 'boolean',
+                    description: 'If the mint authority address is allowed to be from another wallet. Default is false.'
+                  },
                   create_melt: {
                     type: 'boolean',
                     description: 'If should create melt authority for the created NFT. Default is false.'
+                  },
+                  melt_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the melt authority output created.'
+                  },
+                  allow_external_melt_authority_address: {
+                    type: 'boolean',
+                    description: 'If the melt authority address is allowed to be from another wallet. Default is false.'
                   },
                 }
               },

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -397,8 +397,28 @@ async function createToken(req, res) {
   const { name, symbol, amount } = req.body;
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
+  const createMint = req.body.create_mint || true;
+  const mintAuthorityAddress = req.body.mint_authority_address || null;
+  const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
+  const createMelt = req.body.create_melt || true;
+  const meltAuthorityAddress = req.body.melt_authority_address || null;
+  const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {
-    const response = await wallet.createNewToken(name, symbol, amount, { changeAddress, address });
+    const response = await wallet.createNewToken(
+      name,
+      symbol,
+      amount,
+      {
+        changeAddress,
+        address,
+        createMint,
+        mintAuthorityAddress,
+        allowExternalMintAuthorityAddress,
+        createMelt,
+        meltAuthorityAddress,
+        allowExternalMeltAuthorityAddress,
+      }
+    );
     const configurationString = tokensUtils.getConfigurationString(
       response.hash,
       response.name,
@@ -537,14 +557,27 @@ async function createNft(req, res) {
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
   const createMint = req.body.create_mint || false;
+  const mintAuthorityAddress = req.body.mint_authority_address || null;
+  const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
   const createMelt = req.body.create_melt || false;
+  const meltAuthorityAddress = req.body.melt_authority_address || null;
+  const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {
     const response = await wallet.createNFT(
       name,
       symbol,
       amount,
       data,
-      { address, changeAddress, createMint, createMelt }
+      {
+        address,
+        changeAddress,
+        createMint,
+        mintAuthorityAddress,
+        allowExternalMintAuthorityAddress,
+        createMelt,
+        meltAuthorityAddress,
+        allowExternalMeltAuthorityAddress,
+      }
     );
     const configurationString = tokensUtils.getConfigurationString(
       response.hash,

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -397,10 +397,10 @@ async function createToken(req, res) {
   const { name, symbol, amount } = req.body;
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
-  const createMint = req.body.create_mint || true;
+  const createMint = req.body.create_mint === undefined ? true : req.body.create_mint;
   const mintAuthorityAddress = req.body.mint_authority_address || null;
   const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
-  const createMelt = req.body.create_melt || true;
+  const createMelt = req.body.create_melt === undefined ? true : req.body.create_melt;
   const meltAuthorityAddress = req.body.melt_authority_address || null;
   const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -344,6 +344,12 @@ walletRouter.post(
   body('amount').isInt({ min: 1 }).toInt(),
   body('address').isString().optional(),
   body('change_address').isString().optional(),
+  body('create_mint').isBoolean().optional().toBoolean(),
+  body('mint_authority_address').isString().optional(),
+  body('allow_external_mint_authority_address').isBoolean().optional().toBoolean(),
+  body('create_melt').isBoolean().optional().toBoolean(),
+  body('melt_authority_address').isString().optional(),
+  body('allow_external_melt_authority_address').isBoolean().optional().toBoolean(),
   createToken
 );
 
@@ -418,7 +424,11 @@ walletRouter.post(
   body('address').isString().optional(),
   body('change_address').isString().optional(),
   body('create_mint').isBoolean().optional().toBoolean(),
+  body('mint_authority_address').isString().optional(),
+  body('allow_external_mint_authority_address').isBoolean().optional().toBoolean(),
   body('create_melt').isBoolean().optional().toBoolean(),
+  body('melt_authority_address').isString().optional(),
+  body('allow_external_melt_authority_address').isBoolean().optional().toBoolean(),
   createNft
 );
 


### PR DESCRIPTION
### Acceptance Criteria
- Add parameters in the create token endpoint to choose whether the user wants to create mint/melt authorities, define the addresses to where they will be sent, and if it allows external addresses.
- Add parameters in the create nft endpoint to define the addresses to where these authorities will be sent and if it allows external addresses.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
