### PR TITLE
fix: Handling invalid `partial_tx` input errors

### DIFF
--- a/__tests__/atomic-swap/tx-proposal-create.test.js
+++ b/__tests__/atomic-swap/tx-proposal-create.test.js
@@ -123,10 +123,10 @@ describe('create tx-proposal api', () => {
         },
       })
       .set({ 'x-wallet-id': walletId });
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
       success: false,
-      error: 'Invalid serialized partial_tx',
+      error: 'Invalid PartialTx',
     });
   });
 

--- a/__tests__/atomic-swap/tx-proposal-create.test.js
+++ b/__tests__/atomic-swap/tx-proposal-create.test.js
@@ -113,6 +113,23 @@ describe('create tx-proposal api', () => {
     });
   });
 
+  it('should return 400 with an invalid body', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/atomic-swap/tx-proposal')
+      .send({
+        partial_tx: 'invalid-partial-tx',
+        receive: {
+          tokens: [{ value: 5, address: TestUtils.addresses[3] }],
+        },
+      })
+      .set({ 'x-wallet-id': walletId });
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      success: false,
+      error: 'Invalid serialized partial_tx',
+    });
+  });
+
   it('should return 200 with receive.tokens', async () => {
     const response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal')

--- a/__tests__/atomic-swap/tx-proposal-create.test.js
+++ b/__tests__/atomic-swap/tx-proposal-create.test.js
@@ -113,7 +113,7 @@ describe('create tx-proposal api', () => {
     });
   });
 
-  it('should return 400 with an invalid body', async () => {
+  it('should return no success with an invalid partial_tx', async () => {
     const response = await TestUtils.request
       .post('/wallet/atomic-swap/tx-proposal')
       .send({

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -52,13 +52,14 @@ async function buildTxProposal(req, res) {
     return;
   }
 
+  // Deserializing the proposal from the partial_tx, if informed, or creating an empty new one
   let proposal;
   try {
     proposal = partialTx
       ? PartialTxProposal.fromPartialTx(partialTx, wallet.storage)
       : new PartialTxProposal(wallet.storage);
   } catch (e) {
-    res.status(400).json({ success: false, error: 'Invalid serialized partial_tx' });
+    res.json({ success: false, error: e.message });
     return;
   }
 

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -52,9 +52,15 @@ async function buildTxProposal(req, res) {
     return;
   }
 
-  const proposal = partialTx
-    ? PartialTxProposal.fromPartialTx(partialTx, wallet.storage)
-    : new PartialTxProposal(wallet.storage);
+  let proposal;
+  try {
+    proposal = partialTx
+      ? PartialTxProposal.fromPartialTx(partialTx, wallet.storage)
+      : new PartialTxProposal(wallet.storage);
+  } catch (e) {
+    res.status(400).json({ success: false, error: 'Invalid serialized partial_tx' });
+    return;
+  }
 
   if (sendTokens.utxos && sendTokens.utxos.length > 0) {
     try {


### PR DESCRIPTION
### Acceptance Criteria
- Passing an invalid `partial_tx` to `/wallet/atomic-swap/tx-proposal` should result in a treated HTTP response with the error description as a message


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
