### PR TITLE
feat: add parameter to create token and create nft endpoints to set authority addresses

### DIFF
--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils } from '@hathor/wallet-lib';
+import { tokensUtils, transaction as transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
@@ -217,5 +217,119 @@ describe('create-nft routes', () => {
     expect(authorityOutputs.length).toBe(2);
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MINT)).toBeTruthy();
     expect(authorityOutputs.find(o => o.value === AUTHORITY_VALUE.MELT)).toBeTruthy();
+  });
+
+  it('should create the NFT and send authority outputs to the correct address', async done => {
+    await TestUtils.pauseForWsUpdate();
+    // By default, will mint tokens into the next unused address
+    const address0 = await wallet1.getAddressAt(0);
+    const address1 = await wallet1.getAddressAt(1);
+    const response = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        ...nftData,
+        amount: 1,
+        create_mint: true,
+        mint_authority_address: address0,
+        create_melt: true,
+        melt_authority_address: address1,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    const transaction = response.body;
+    expect(transaction.success).toBe(true);
+
+    // Validating a new mint authority was created
+    const authorityOutputs = transaction.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs).toHaveLength(2);
+    const mintOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MINT_MASK
+    );
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
+    // Validate that the mint output was sent to the correct address
+    expect(mintP2pkh.address.base58).toEqual(address0);
+
+    const meltOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MELT_MASK
+    );
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
+    // Validate that the melt output was sent to the correct address
+    expect(meltP2pkh.address.base58).toEqual(address1);
+
+    done();
+  });
+
+  it('Create nft using external mint/melt address', async done => {
+    await TestUtils.pauseForWsUpdate();
+    const address2idx0 = await wallet2.getAddressAt(0);
+    const address2idx1 = await wallet2.getAddressAt(1);
+
+    // External address for mint won't be successful
+    const response = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        ...nftData,
+        amount: 1,
+        create_mint: true,
+        mint_authority_address: address2idx0,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response.body.success).toBe(false);
+
+    // External address for melt won't be successful
+    const response2 = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        ...nftData,
+        amount: 1,
+        create_melt: true,
+        melt_authority_address: address2idx1,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response2.body.success).toBe(false);
+
+    // External address for both authorities will succeed with parameter allowing it
+    const response3 = await TestUtils.request
+      .post('/wallet/create-nft')
+      .send({
+        ...nftData,
+        amount: 1,
+        create_mint: true,
+        mint_authority_address: address2idx0,
+        allow_external_mint_authority_address: true,
+        create_melt: true,
+        melt_authority_address: address2idx1,
+        allow_external_melt_authority_address: true,
+      })
+      .set({ 'x-wallet-id': wallet1.walletId });
+
+    expect(response3.body.success).toBe(true);
+
+    const transaction = response3.body;
+
+    // Validating a new mint authority was created
+    const authorityOutputs = transaction.outputs.filter(
+      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs).toHaveLength(2);
+    const mintOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MINT_MASK
+    );
+    const mintP2pkh = scriptsUtils.parseP2PKH(Buffer.from(mintOutput[0].script.data), network);
+    // Validate that the mint output was sent to the correct address
+    expect(mintP2pkh.address.base58).toEqual(address2idx0);
+
+    const meltOutput = authorityOutputs.filter(
+      o => o.value === constants.TOKEN_MELT_MASK
+    );
+    const meltP2pkh = scriptsUtils.parseP2PKH(Buffer.from(meltOutput[0].script.data), network);
+    // Validate that the melt output was sent to the correct address
+    expect(meltP2pkh.address.base58).toEqual(address2idx1);
+
+    done();
   });
 });

--- a/__tests__/integration/create-nft.test.js
+++ b/__tests__/integration/create-nft.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
+import { tokensUtils, transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
 import { AUTHORITY_VALUE, TOKEN_DATA } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
@@ -241,7 +241,7 @@ describe('create-nft routes', () => {
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(
@@ -313,7 +313,7 @@ describe('create-nft routes', () => {
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(

--- a/__tests__/integration/create-token.test.js
+++ b/__tests__/integration/create-token.test.js
@@ -1,4 +1,4 @@
-import { tokensUtils, transaction as transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
+import { tokensUtils, transactionUtils, constants, network, scriptsUtils } from '@hathor/wallet-lib';
 import { getRandomInt } from './utils/core.util';
 import { TestUtils } from './utils/test-utils-integration';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
@@ -300,7 +300,7 @@ describe('create token', () => {
 
     // Validating authority tokens
     const authorityOutputs = tx.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs.length).toBe(1);
     expect(authorityOutputs[0].value).toBe(constants.TOKEN_MINT_MASK);
@@ -328,7 +328,7 @@ describe('create token', () => {
 
     // Validating authority tokens
     const authorityOutputs = tx.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs.length).toBe(1);
     expect(authorityOutputs[0].value).toBe(constants.TOKEN_MELT_MASK);
@@ -354,7 +354,7 @@ describe('create token', () => {
 
     // Validating authority tokens
     const authorityOutputs = tx.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs.length).toBe(2);
     expect(authorityOutputs.find(o => o.value === constants.TOKEN_MINT_MASK)).toBeTruthy();
@@ -385,7 +385,7 @@ describe('create token', () => {
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(
@@ -462,7 +462,7 @@ describe('create token', () => {
 
     // Validating a new mint authority was created
     const authorityOutputs = transaction.outputs.filter(
-      o => transactionUtils.isTokenDataAuthority(o.tokenData)
+      o => transactionUtils.isAuthorityOutput({ token_data: o.tokenData })
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -2530,6 +2530,30 @@ const apiDoc = {
                     type: 'string',
                     description: 'Optional address to send the change amount.'
                   },
+                  create_mint: {
+                    type: 'boolean',
+                    description: 'If should create mint authority for the created token. Default is true.'
+                  },
+                  mint_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the mint authority output created.'
+                  },
+                  allow_external_mint_authority_address: {
+                    type: 'boolean',
+                    description: 'If the mint authority address is allowed to be from another wallet. Default is false.'
+                  },
+                  create_melt: {
+                    type: 'boolean',
+                    description: 'If should create melt authority for the created token. Default is true.'
+                  },
+                  melt_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the melt authority output created.'
+                  },
+                  allow_external_melt_authority_address: {
+                    type: 'boolean',
+                    description: 'If the melt authority address is allowed to be from another wallet. Default is false.'
+                  },
                 }
               },
               examples: {
@@ -2818,9 +2842,25 @@ const apiDoc = {
                     type: 'boolean',
                     description: 'If should create mint authority for the created NFT. Default is false.'
                   },
+                  mint_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the mint authority output created.'
+                  },
+                  allow_external_mint_authority_address: {
+                    type: 'boolean',
+                    description: 'If the mint authority address is allowed to be from another wallet. Default is false.'
+                  },
                   create_melt: {
                     type: 'boolean',
                     description: 'If should create melt authority for the created NFT. Default is false.'
+                  },
+                  melt_authority_address: {
+                    type: 'string',
+                    description: 'Optional address to send the melt authority output created.'
+                  },
+                  allow_external_melt_authority_address: {
+                    type: 'boolean',
+                    description: 'If the melt authority address is allowed to be from another wallet. Default is false.'
                   },
                 }
               },

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -435,11 +435,33 @@ async function createToken(req, res) {
   const { name, symbol, amount } = req.body;
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
+  const createMint = req.body.create_mint === undefined ? true : req.body.create_mint;
+  const mintAuthorityAddress = req.body.mint_authority_address || null;
+  const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
+  const createMelt = req.body.create_melt === undefined ? true : req.body.create_melt;
+  const meltAuthorityAddress = req.body.melt_authority_address || null;
+  const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {
     if (changeAddress && !await wallet.isAddressMine(changeAddress)) {
       throw new Error('Change address is not from this wallet');
     }
-    const response = await wallet.createNewToken(name, symbol, amount, { changeAddress, address });
+
+    const response = await wallet.createNewToken(
+      name,
+      symbol,
+      amount,
+      {
+        changeAddress,
+        address,
+        createMint,
+        mintAuthorityAddress,
+        allowExternalMintAuthorityAddress,
+        createMelt,
+        meltAuthorityAddress,
+        allowExternalMeltAuthorityAddress,
+      }
+    );
+
     const configurationString = tokensUtils.getConfigurationString(
       response.hash,
       response.name,
@@ -610,7 +632,11 @@ async function createNft(req, res) {
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
   const createMint = req.body.create_mint || false;
+  const mintAuthorityAddress = req.body.mint_authority_address || null;
+  const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
   const createMelt = req.body.create_melt || false;
+  const meltAuthorityAddress = req.body.melt_authority_address || null;
+  const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {
     if (changeAddress && !await wallet.isAddressMine(changeAddress)) {
       throw new Error('Change address is not from this wallet');
@@ -620,7 +646,16 @@ async function createNft(req, res) {
       symbol,
       amount,
       data,
-      { address, changeAddress, createMint, createMelt }
+      {
+        address,
+        changeAddress,
+        createMint,
+        mintAuthorityAddress,
+        allowExternalMintAuthorityAddress,
+        createMelt,
+        meltAuthorityAddress,
+        allowExternalMeltAuthorityAddress,
+      }
     );
     const configurationString = tokensUtils.getConfigurationString(
       response.hash,

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -435,10 +435,10 @@ async function createToken(req, res) {
   const { name, symbol, amount } = req.body;
   const address = req.body.address || null;
   const changeAddress = req.body.change_address || null;
-  const createMint = req.body.create_mint === undefined ? true : req.body.create_mint;
+  const createMint = req.body.create_mint ?? true;
   const mintAuthorityAddress = req.body.mint_authority_address || null;
   const allowExternalMintAuthorityAddress = req.body.allow_external_mint_authority_address || false;
-  const createMelt = req.body.create_melt === undefined ? true : req.body.create_melt;
+  const createMelt = req.body.create_melt ?? true;
   const meltAuthorityAddress = req.body.melt_authority_address || null;
   const allowExternalMeltAuthorityAddress = req.body.allow_external_melt_authority_address || false;
   try {

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -344,6 +344,12 @@ walletRouter.post(
   body('amount').isInt({ min: 1 }).toInt(),
   body('address').isString().optional(),
   body('change_address').isString().optional(),
+  body('create_mint').isBoolean().optional().toBoolean(),
+  body('mint_authority_address').isString().optional(),
+  body('allow_external_mint_authority_address').isBoolean().optional().toBoolean(),
+  body('create_melt').isBoolean().optional().toBoolean(),
+  body('melt_authority_address').isString().optional(),
+  body('allow_external_melt_authority_address').isBoolean().optional().toBoolean(),
   createToken
 );
 
@@ -422,7 +428,11 @@ walletRouter.post(
   body('address').isString().optional(),
   body('change_address').isString().optional(),
   body('create_mint').isBoolean().optional().toBoolean(),
+  body('mint_authority_address').isString().optional(),
+  body('allow_external_mint_authority_address').isBoolean().optional().toBoolean(),
   body('create_melt').isBoolean().optional().toBoolean(),
+  body('melt_authority_address').isString().optional(),
+  body('allow_external_melt_authority_address').isBoolean().optional().toBoolean(),
   createNft
 );
 


### PR DESCRIPTION
### Acceptance Criteria
- Add parameters in the create token endpoint to choose whether the user wants to create mint/melt authorities, define the addresses to where they will be sent, and if it allows external addresses.
- Add parameters in the create nft endpoint to define the addresses to where these authorities will be sent and if it allows external addresses.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
