### PR TITLE
chore: install build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM node:16.14-alpine3.14
 WORKDIR /usr/src/app/
 
 COPY .babelrc package.json package-lock.json ./
-RUN npm install
+RUN apk add --no-cache --virtual .gyp python3 make g++ &&\
+    npm install &&\
+    apk del .gyp
 
 COPY ./src/ ./src/
 COPY ./scripts/ ./scripts/


### PR DESCRIPTION
### Motivation

During the release of the last version we found out the docker build was failing due to missing dependencies.

### Acceptance Criteria
- Include build deps when installing deps on docker


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
