### PR TITLE
chore: deprecate set-output command

### DIFF
--- a/scripts/github/docker.py
+++ b/scripts/github/docker.py
@@ -54,9 +54,11 @@ def prep_tags(environ: Dict):
     return tags
 
 def print_output(output: Dict):
-    outputs = ['{}={}'.format(k, v) for k, v in output.items()]
+    outputs = []
     if os.environ['GITHUB_OUTPUT']:
-        outputs = [os.environ['GITHUB_OUTPUT']] + outputs
+        outputs.append(os.environ['GITHUB_OUTPUT'])
+    for k, v in output.items():
+        outputs.append('{}={}'.format(k, v))
     os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
 
 if __name__ == '__main__':

--- a/scripts/github/docker.py
+++ b/scripts/github/docker.py
@@ -54,12 +54,9 @@ def prep_tags(environ: Dict):
     return tags
 
 def print_output(output: Dict):
-    outputs = []
-    if os.environ['GITHUB_OUTPUT']:
-        outputs.append(os.environ['GITHUB_OUTPUT'])
-    for k, v in output.items():
-        outputs.append('{}={}'.format(k, v))
-    os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
+    outputs = ['{}={}'.format(k, v) for k, v in output.items()]
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+        f.writelines(outputs)
 
 if __name__ == '__main__':
     tags = prep_tags(os.environ)

--- a/scripts/github/docker.py
+++ b/scripts/github/docker.py
@@ -54,8 +54,10 @@ def prep_tags(environ: Dict):
     return tags
 
 def print_output(output: Dict):
-    for k, v in output.items():
-        print(f'::set-output name={k}::{v}')
+    outputs = ['{}={}'.format(k, v) for k, v in output.items()]
+    if os.environ['GITHUB_OUTPUT']:
+        outputs = [os.environ['GITHUB_OUTPUT']] + outputs
+    os.environ['GITHUB_OUTPUT'] = '\n'.join(outputs)
 
 if __name__ == '__main__':
     tags = prep_tags(os.environ)


### PR DESCRIPTION
### Acceptance Criteria
- Deprecate set-output command ([reference](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
