### PR TITLE
chore: add missing endl in github output

### DIFF
--- a/scripts/github/docker.py
+++ b/scripts/github/docker.py
@@ -54,7 +54,7 @@ def prep_tags(environ: Dict):
     return tags
 
 def print_output(output: Dict):
-    outputs = ['{}={}'.format(k, v) for k, v in output.items()]
+    outputs = ['{}={}\n'.format(k, v) for k, v in output.items()]
     with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
         f.writelines(outputs)
 


### PR DESCRIPTION
### Acceptance Criteria

- Add missing separator for github outputs


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
