### PR TITLE
feat: add token to decode when the spent tx is not ours

### DIFF
--- a/__tests__/decode.test.js
+++ b/__tests__/decode.test.js
@@ -85,7 +85,7 @@ describe('decode api', () => {
     const expected = {
       success: true,
       tx: {
-        type: "Transaction",
+        type: 'Transaction',
         version: 1,
         completeSignatures: false,
         tokens: [],

--- a/__tests__/decode.test.js
+++ b/__tests__/decode.test.js
@@ -1,5 +1,5 @@
 import { PartialTx, ProposalInput, ProposalOutput } from '@hathor/wallet-lib/lib/models/partial_tx';
-import { Network, Address, P2PKH } from '@hathor/wallet-lib';
+import { Network, Address, P2PKH, Transaction, Input, Output, HathorWallet } from '@hathor/wallet-lib';
 import httpFixtures from './__fixtures__/http-fixtures';
 import TestUtils from './test-utils';
 
@@ -244,5 +244,84 @@ describe('decode api', () => {
     });
 
     spy.mockRestore();
+  });
+
+  it('should fetch the correct token from the tx the inputs are spending', async () => {
+    const txId0 = '5db0a8c77f818c51cb107532fc1a36785adfa700d81d973fd1f23438b2f3dd74';
+    const txId1 = 'fb2fbe0385bc0bc8e9a255a8d530f7b3bdcebcd5ccdae5e154e6c3d57cbcd143';
+    const txId2 = '11835fae291c60fc58314c61d27dc644b9e029c363bbe458039b2b0186144275';
+    const tx = new Transaction(
+      [new Input(txId0, 0), new Input(txId1, 1), new Input(txId2, 2)],
+      [new Output(100, Buffer.from('0463616665ac', 'hex'))],
+      {
+        timestamp: 123,
+        parents: ['f6c83e3641a08ec21aebc01296ff12f5a46780f0fbadb1c8101309123b95d2c6'],
+      },
+    );
+
+    const txHex = tx.toHex();
+
+    const txObj = {
+      tokens: ['token1'],
+      outputs: [
+        {
+          decoded: {
+            type: 'P2PKH',
+            address: 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
+          },
+          value: 1,
+          token_data: 0,
+          script: 'input0-script',
+        },
+        {
+          decoded: {
+            type: 'P2PKH',
+            address: 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
+          },
+          value: 1,
+          token_data: 1,
+          script: 'input1-script',
+        },
+        {
+          decoded: {
+            type: 'P2PKH',
+            address: 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
+          },
+          value: 1,
+          token_data: 2,
+          script: 'input1-script',
+        },
+      ],
+    };
+    const getTxMock = jest.spyOn(HathorWallet.prototype, 'getFullTxById').mockImplementation(async () => ({
+      success: true,
+      tx: txObj,
+    }));
+
+    const response = await TestUtils.request
+      .post('/wallet/decode')
+      .send({ txHex })
+      .set({ 'x-wallet-id': walletId });
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.tx).toBeDefined();
+    // inputs
+    expect(response.body.tx.inputs).toBeDefined();
+    expect(response.body.tx.inputs[0].index).toEqual(0);
+    expect(response.body.tx.inputs[0].txId).toEqual(txId0);
+    expect(response.body.tx.inputs[0].token).toEqual('00');
+    expect(response.body.tx.inputs[1].index).toEqual(1);
+    expect(response.body.tx.inputs[1].txId).toEqual(txId1);
+    expect(response.body.tx.inputs[1].token).toEqual('token1');
+    expect(response.body.tx.inputs[2].index).toEqual(2);
+    expect(response.body.tx.inputs[2].txId).toEqual(txId2);
+    expect(response.body.tx.inputs[2].token).not.toBeDefined();
+    // outputs
+    expect(response.body.tx.outputs).toBeDefined();
+    expect(response.body.tx.outputs.length).toBe(tx.outputs.length);
+    expect(response.body.tx.outputs[0].decoded.address).toBe(tx.outputs[0].address);
+    expect(response.body.tx.outputs[0].value).toBe(100);
+
+    getTxMock.mockRestore();
   });
 });

--- a/__tests__/decode.test.js
+++ b/__tests__/decode.test.js
@@ -85,6 +85,8 @@ describe('decode api', () => {
     const expected = {
       success: true,
       tx: {
+        type: "Transaction",
+        version: 1,
         completeSignatures: false,
         tokens: [],
         inputs: [],

--- a/__tests__/integration/multisig.test.js
+++ b/__tests__/integration/multisig.test.js
@@ -423,6 +423,8 @@ describe('send tx (HTR)', () => {
       success: true,
       tx: {
         completeSignatures: false,
+        type: 'Create Token Transaction',
+        version: 2,
         tokens: [],
         inputs: [
           {
@@ -522,6 +524,8 @@ describe('send tx (HTR)', () => {
       success: true,
       tx: expect.objectContaining({
         completeSignatures: false,
+        type: 'Transaction',
+        version: 1,
         tokens: [txCreateToken.hash],
         inputs: [
           expect.objectContaining({
@@ -626,6 +630,8 @@ describe('send tx (HTR)', () => {
     expect(response.body).toEqual({
       success: true,
       tx: {
+        type: 'Transaction',
+        version: 1,
         tokens: [
           txCreateToken.hash,
         ],

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -201,7 +201,8 @@ async function start(req, res) {
   wallet.start().then(info => {
     // The replace avoids Log Injection
     console.log(
-      `Wallet started with wallet id ${sanitizeLogInput(walletID)}. Full-node info: ${JSON.stringify(info, null, 2)}`
+      `Wallet started with wallet id ${sanitizeLogInput(walletID)}. \
+Full-node info: ${JSON.stringify(info, null, 2)}`
     );
 
     initializedWallets.set(walletID, wallet);

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -201,7 +201,7 @@ async function start(req, res) {
   wallet.start().then(info => {
     // The replace avoids Log Injection
     console.log(
-      `Wallet started with wallet id ${sanitizeLogInput(walletID)}. Full-node info: ${info}`
+      `Wallet started with wallet id ${sanitizeLogInput(walletID)}. Full-node info: ${JSON.stringify(info, null, 2)}`
     );
 
     initializedWallets.set(walletID, wallet);

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -294,7 +294,7 @@ async function decodeTx(req, res) {
     const tokenIndex = (utxo.token_data & TOKEN_INDEX_MASK) - 1;
     if (txObj.tokens.length > tokenIndex) return txObj.tokens[tokenIndex];
     return undefined;
-  };
+  }
 
   const validationResult = parametersValidation(req);
   if (!validationResult.success) {

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -318,12 +318,12 @@ async function decodeTx(req, res) {
       tx = partial.getTx();
     }
 
-    const getToken = utxo => {
+    const getToken = (utxo, txObj) => {
       if (utxo.token) return utxo.token;
       if (utxo.token_data === 0) return HATHOR_TOKEN_CONFIG.uid;
 
       const tokenIndex = (utxo.token_data & TOKEN_INDEX_MASK) - 1;
-      if (tx.tokens.length > tokenIndex) return tx.tokens[tokenIndex];
+      if (txObj.tokens.length > tokenIndex) return txObj.tokens[tokenIndex];
       return undefined;
     };
 
@@ -342,7 +342,7 @@ async function decodeTx(req, res) {
           txId: input.hash,
           index: input.index,
           decoded: utxo.decoded,
-          token: getToken(utxo),
+          token: getToken(utxo, _tx),
           value: utxo.value,
           // This is required by transactionUtils.getTxBalance
           // It should be ignored by users


### PR DESCRIPTION
### Acceptance Criteria
- When the spent transaction is not from our wallet the token field would come as `undefined` and `JSON.stringify` would remove the token property from the decoded transaction.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
