### PR TITLE
feat: new healthcheck endpoint

### DIFF
--- a/__tests__/__fixtures__/http-fixtures.js
+++ b/__tests__/__fixtures__/http-fixtures.js
@@ -1,4 +1,7 @@
 export default {
+  'http://fake.txmining:8084/health': {
+    status: 'pass'
+  },
   '/v1a/version': {
     version: '0.38.4',
     network: 'testnet-foxtrot',

--- a/__tests__/__fixtures__/settings-fixture.js
+++ b/__tests__/__fixtures__/settings-fixture.js
@@ -5,6 +5,7 @@ const defaultConfig = {
   http_port: 8001,
   network: 'testnet',
   server: 'http://fakehost:8083/v1a/',
+  txMiningUrl: 'http://fake.txmining:8084/',
   seeds: {
     stub_seed:
       'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind',

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -27,13 +27,25 @@ describe('healthcheck api', () => {
   });
 
   describe('/health', () => {
-    it('should return 400 when the x-wallet-ids header is not provided', async () => {
+    it('should return 400 when the x-wallet-id is invalid', async () => {
       const response = await TestUtils.request
+        .query({ 'x-wallet-ids': 'invalid' })
         .get('/health');
+
       expect(response.status).toBe(400);
       expect(response.body).toStrictEqual({
         success: false,
-        message: 'Header \'X-Wallet-Ids\' is required.',
+        message: 'Invalid wallet id parameter: invalid',
+      });
+    });
+
+    it('should return 400 when no component is included', async () => {
+      const response = await TestUtils.request.get('/health');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toStrictEqual({
+        success: false,
+        message: 'At least one component must be included in the health check',
       });
     });
 
@@ -44,7 +56,11 @@ describe('healthcheck api', () => {
       );
 
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': `${walletId},${anotherWalletId}` })
+        .query({
+          'include-tx-mining': true,
+          'include-fullnode': true,
+          'x-wallet-ids': `${walletId},${anotherWalletId}`
+        })
         .get('/health');
       expect(response.status).toBe(200);
 
@@ -101,7 +117,7 @@ describe('healthcheck api', () => {
       wallet.state = HathorWallet.SYNCING;
 
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId })
+        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -147,7 +163,7 @@ describe('healthcheck api', () => {
       TestUtils.httpMock.onGet('/version').reply(503, { status: 'fail' });
 
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId })
+        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -193,7 +209,7 @@ describe('healthcheck api', () => {
       );
 
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId })
+        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -231,13 +247,11 @@ describe('healthcheck api', () => {
         }
       });
     });
-  });
 
-  describe('/health/wallets', () => {
-    it('should return 200 when the wallets are ready', async () => {
+    it('should not include the fullnode when the parameter is missing', async () => {
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': `${walletId},${anotherWalletId}` })
-        .get('/health/wallets');
+        .query({ 'include-tx-mining': true, 'x-wallet-ids': walletId })
+        .get('/health');
       expect(response.status).toBe(200);
 
       expect(response.body).toStrictEqual({
@@ -253,12 +267,12 @@ describe('healthcheck api', () => {
               time: expect.any(String),
             },
           ],
-          'Wallet another_health_wallet': [
+          'TxMiningService http://fake.txmining:8084/': [
             {
-              componentName: 'Wallet another_health_wallet',
-              componentType: 'internal',
+              componentName: 'TxMiningService http://fake.txmining:8084/',
+              componentType: 'service',
               status: 'pass',
-              output: 'Wallet is ready',
+              output: 'Tx Mining Service is healthy',
               time: expect.any(String),
             },
           ],
@@ -266,147 +280,35 @@ describe('healthcheck api', () => {
       });
     });
 
-    it('should return 400 when the wallet has been started, but the header was not passed', async () => {
+    it('should not include the tx mining service when the parameter is missing', async () => {
       const response = await TestUtils.request
-        .get('/health/wallets');
-      expect(response.status).toBe(400);
-
-      expect(response.body).toStrictEqual({
-        success: false,
-        message: 'Header \'X-Wallet-Ids\' is required.',
-      });
-    });
-
-    it('should return 400 when the wallet has not been started', async () => {
-      const response = await TestUtils.request
-        .set({ 'x-wallet-ids': `invalid-id,${walletId}` })
-        .get('/health/wallets');
-      expect(response.status).toBe(400);
-
-      expect(response.body).toStrictEqual({
-        success: false,
-        message: 'Invalid wallet id parameter: invalid-id',
-      });
-    });
-
-    it('should return 503 when the wallet is not ready', async () => {
-      const wallet = initializedWallets.get(walletId);
-      const originalIsReady = wallet.isReady;
-      const originalState = wallet.state;
-      wallet.isReady = () => false;
-      wallet.state = HathorWallet.SYNCING;
-
-      const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId })
-        .get('/health/wallets');
-      expect(response.status).toBe(503);
-
-      wallet.isReady = originalIsReady;
-      wallet.state = originalState;
-    });
-  });
-
-  describe('/health/fullnode', () => {
-    it('should return 503 when the request to the fullnode fails', async () => {
-      TestUtils.httpMock.onGet('/version').networkError();
-
-      const response = await TestUtils.request
-        .get('/health/fullnode');
-
-      expect(response.status).toBe(503);
-      expect(response.body).toStrictEqual({
-        status: 'fail',
-        output: 'Error getting fullnode health: Network Error',
-        componentName: 'Fullnode http://fakehost:8083/v1a/',
-        componentType: 'fullnode',
-        time: expect.any(String),
-      });
-    });
-
-    it('should return 503 when the fullnode reports as unhealthy', async () => {
-      TestUtils.httpMock.onGet('/version').reply(503, { status: 'fail' });
-
-      const response = await TestUtils.request
-        .get('/health/fullnode');
-
-      expect(response.status).toBe(503);
-
-      expect(response.body).toStrictEqual({
-        status: 'fail',
-        output: 'Fullnode reported as unhealthy: {"status":"fail"}',
-        componentName: 'Fullnode http://fakehost:8083/v1a/',
-        componentType: 'fullnode',
-        time: expect.any(String),
-      });
-    });
-
-    it('should return 200 when the fullnode is ready', async () => {
-      const response = await TestUtils.request
-        .get('/health/fullnode');
+        .query({ 'include-fullnode': true, 'x-wallet-ids': walletId })
+        .get('/health');
       expect(response.status).toBe(200);
 
       expect(response.body).toStrictEqual({
         status: 'pass',
-        output: 'Fullnode is responding',
-        componentName: 'Fullnode http://fakehost:8083/v1a/',
-        componentType: 'fullnode',
-        time: expect.any(String),
-      });
-    });
-  });
-
-  describe('/health/tx-mining-service', () => {
-    it('should return 503 when the tx mining service reports as unhealthy', async () => {
-      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
-        503,
-        { status: 'fail' }
-      );
-
-      const response = await TestUtils.request
-        .get('/health/tx-mining');
-      expect(response.status).toBe(503);
-
-      expect(response.body).toStrictEqual({
-        status: 'fail',
-        output: 'Tx Mining Service reported as unhealthy: {"status":"fail"}',
-        componentName: 'TxMiningService http://fake.txmining:8084/',
-        componentType: 'service',
-        time: expect.any(String),
-      });
-    });
-
-    it('should return 503 when the request to the tx mining service fails', async () => {
-      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').networkError();
-
-      const response = await TestUtils.request
-        .get('/health/tx-mining');
-      expect(response.status).toBe(503);
-
-      expect(response.body).toStrictEqual({
-        status: 'fail',
-        output: 'Error getting tx-mining-service health: Network Error',
-        componentName: 'TxMiningService http://fake.txmining:8084/',
-        componentType: 'service',
-        time: expect.any(String),
-      });
-    });
-
-    it('should return 200 when the tx mining service is healthy', async () => {
-      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
-        200,
-        { status: 'pass' }
-      );
-
-      const response = await TestUtils.request
-        .get('/health/tx-mining');
-      expect(response.status).toBe(200);
-
-      expect(response.body).toStrictEqual({
-        status: 'pass',
-        output: 'Tx Mining Service is healthy',
-        componentName: 'TxMiningService http://fake.txmining:8084/',
-        componentType: 'service',
-        time: expect.any(String),
+        description: 'Wallet-headless health',
+        checks: {
+          'Wallet health_wallet': [
+            {
+              componentName: 'Wallet health_wallet',
+              componentType: 'internal',
+              status: 'pass',
+              output: 'Wallet is ready',
+              time: expect.any(String),
+            },
+          ],
+          'Fullnode http://fakehost:8083/v1a/': [
+            {
+              componentName: 'Fullnode http://fakehost:8083/v1a/',
+              componentType: 'fullnode',
+              status: 'pass',
+              output: 'Fullnode is responding',
+              time: expect.any(String),
+            },
+          ],
+        }
       });
     });
   });

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -9,12 +9,15 @@ const anotherWalletId = 'another_health_wallet';
 describe('healthcheck api', () => {
   beforeAll(async () => {
     await TestUtils.startWallet({ walletId, preCalculatedAddresses: TestUtils.addresses });
-    await TestUtils.startWallet({ walletId: anotherWalletId, preCalculatedAddresses: TestUtils.addresses });
+    await TestUtils.startWallet({
+      walletId: anotherWalletId,
+      preCalculatedAddresses: TestUtils.addresses
+    });
   });
 
   afterAll(async () => {
     await TestUtils.stopWallet({ walletId });
-    await TestUtils.stopWallet({ walletId: anotherWalletId })
+    await TestUtils.stopWallet({ walletId: anotherWalletId });
   });
 
   afterEach(async () => {
@@ -41,7 +44,7 @@ describe('healthcheck api', () => {
       );
 
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId + ',' + anotherWalletId })
+        .set({ 'x-wallet-ids': `${walletId},${anotherWalletId}` })
         .get('/health');
       expect(response.status).toBe(200);
 
@@ -233,7 +236,7 @@ describe('healthcheck api', () => {
   describe('/health/wallets', () => {
     it('should return 200 when the wallets are ready', async () => {
       const response = await TestUtils.request
-        .set({ 'x-wallet-ids': walletId + ',' + anotherWalletId })
+        .set({ 'x-wallet-ids': `${walletId},${anotherWalletId}` })
         .get('/health/wallets');
       expect(response.status).toBe(200);
 

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -1,0 +1,82 @@
+import TestUtils from './test-utils';
+const { initializedWallets } = require('../src/services/wallets.service');
+
+const walletId = 'stub_status';
+
+describe('healthcheck api', () => {
+  describe('/health/wallet', () => {
+    it('should return 400 when the wallet has not been started', async () => {
+      const response = await TestUtils.request
+        .get('/health/wallet')
+        .set({ 'x-wallet-id': walletId });
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Invalid wallet id parameter.');
+    })
+
+    it('should return 400 when the wallet has been started, but the header was not passed', async () => {
+      await TestUtils.startWallet({ walletId, preCalculatedAddresses: TestUtils.addresses });
+
+      const response = await TestUtils.request
+        .get('/health/wallet');
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toBe('Header \'X-Wallet-Id\' is required.');
+
+      await TestUtils.stopWallet({ walletId });
+    })
+
+    it('should return 503 when the wallet is not ready', async () => {
+      await TestUtils.startWallet({ walletId });
+
+      initializedWallets.get(walletId).isReady = () => false;
+
+      const response = await TestUtils.request
+        .get('/health/wallet')
+        .set({ 'x-wallet-id': walletId });
+      expect(response.status).toBe(503);
+
+      await TestUtils.stopWallet({ walletId });
+    })
+  });
+
+  describe('/health/fullnode', () => {
+    it('should return 503 when the request to the fullnode fails', async () => {
+      const response = await TestUtils.request
+        .get('/health/fullnode');
+      expect(response.status).toBe(503);
+    })
+
+    it('should return 503 when the fullnode resports as unhealthy', async () => {
+      const response = await TestUtils.request
+        .get('/health/fullnode');
+      expect(response.status).toBe(503);
+    })
+
+    it('should return 200 when the fullnode is ready', async () => {
+      const response = await TestUtils.request
+        .get('/health/fullnode');
+      expect(response.status).toBe(200);
+    })
+  });
+
+  describe('/health/tx-mining-service', () => {
+    it('should return 503 when the request to the tx mining service fails', async () => {
+      const response = await TestUtils.request
+        .get('/health/tx-mining-service');
+      expect(response.status).toBe(503);
+    })
+
+    it('should return 503 when the tx mining service resports as unhealthy', async () => {
+      const response = await TestUtils.request
+        .get('/health/tx-mining-service');
+      expect(response.status).toBe(503);
+    })
+
+    it('should return 200 when the tx mining service is ready', async () => {
+      const response = await TestUtils.request
+        .get('/health/tx-mining-service');
+      expect(response.status).toBe(200);
+    })
+  });
+});

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -1,9 +1,142 @@
+import { HathorWallet } from '@hathor/wallet-lib';
 import TestUtils from './test-utils';
+
 const { initializedWallets } = require('../src/services/wallets.service');
 
 const walletId = 'stub_status';
 
 describe('healthcheck api', () => {
+  afterEach(async () => {
+    await TestUtils.stopMocks();
+    TestUtils.startMocks();
+  });
+
+  describe('/health', () => {
+    it('should return 200 when all components are healthy', async () => {
+      await TestUtils.startWallet({ walletId, preCalculatedAddresses: TestUtils.addresses });
+
+      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
+        200,
+        { status: 'pass' }
+      );
+
+      const response = await TestUtils.request
+        .get('/health');
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('pass');
+      expect(response.body.description).toBe('Wallet-headless health');
+
+      expect(response.body.checks['Wallet stub_status'][0].componentName).toBe('Wallet stub_status');
+      expect(response.body.checks['Wallet stub_status'][0].componentType).toBe('internal');
+      expect(response.body.checks['Wallet stub_status'][0].status).toBe('pass');
+      expect(response.body.checks['Wallet stub_status'][0].output).toBe('Wallet is ready');
+
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
+
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+
+      await TestUtils.stopWallet({ walletId });
+    });
+
+    it('should return 503 when the wallet is not ready', async () => {
+      await TestUtils.startWallet({ walletId });
+
+      const wallet = initializedWallets.get(walletId);
+      wallet.isReady = () => false;
+      wallet.state = HathorWallet.SYNCING;
+
+      const response = await TestUtils.request
+        .get('/health');
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.description).toBe('Wallet-headless health');
+
+      expect(response.body.checks['Wallet stub_status'][0].componentName).toBe('Wallet stub_status');
+      expect(response.body.checks['Wallet stub_status'][0].componentType).toBe('internal');
+      expect(response.body.checks['Wallet stub_status'][0].status).toBe('fail');
+      expect(response.body.checks['Wallet stub_status'][0].output).toBe('Wallet is not ready. Current state: Syncing');
+
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
+
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+
+      await TestUtils.stopWallet({ walletId });
+    });
+
+    it('should return 503 when the fullnode is not healthy', async () => {
+      await TestUtils.startWallet({ walletId });
+
+      TestUtils.httpMock.onGet('/version').reply(503, { status: 'fail' });
+
+      const response = await TestUtils.request
+        .get('/health');
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.description).toBe('Wallet-headless health');
+
+      expect(response.body.checks['Wallet stub_status'][0].componentName).toBe('Wallet stub_status');
+      expect(response.body.checks['Wallet stub_status'][0].componentType).toBe('internal');
+      expect(response.body.checks['Wallet stub_status'][0].status).toBe('pass');
+      expect(response.body.checks['Wallet stub_status'][0].output).toBe('Wallet is ready');
+
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('fail');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode reported as unhealthy: {"status":"fail"}');
+
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+
+      await TestUtils.stopWallet({ walletId });
+    });
+
+    it('should return 503 when the tx mining service is not healthy', async () => {
+      await TestUtils.startWallet({ walletId });
+
+      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
+        503,
+        { status: 'fail' }
+      );
+
+      const response = await TestUtils.request
+        .get('/health');
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.description).toBe('Wallet-headless health');
+
+      expect(response.body.checks['Wallet stub_status'][0].componentName).toBe('Wallet stub_status');
+      expect(response.body.checks['Wallet stub_status'][0].componentType).toBe('internal');
+      expect(response.body.checks['Wallet stub_status'][0].status).toBe('pass');
+      expect(response.body.checks['Wallet stub_status'][0].output).toBe('Wallet is ready');
+
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
+      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
+
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('fail');
+      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service reported as unhealthy: {"status":"fail"}');
+
+      await TestUtils.stopWallet({ walletId });
+    });
+  });
+
   describe('/health/wallet', () => {
     it('should return 400 when the wallet has not been started', async () => {
       const response = await TestUtils.request
@@ -12,7 +145,7 @@ describe('healthcheck api', () => {
       expect(response.status).toBe(400);
       expect(response.body.success).toBe(false);
       expect(response.body.message).toBe('Invalid wallet id parameter.');
-    })
+    });
 
     it('should return 400 when the wallet has been started, but the header was not passed', async () => {
       await TestUtils.startWallet({ walletId, preCalculatedAddresses: TestUtils.addresses });
@@ -24,12 +157,14 @@ describe('healthcheck api', () => {
       expect(response.body.message).toBe('Header \'X-Wallet-Id\' is required.');
 
       await TestUtils.stopWallet({ walletId });
-    })
+    });
 
     it('should return 503 when the wallet is not ready', async () => {
       await TestUtils.startWallet({ walletId });
 
-      initializedWallets.get(walletId).isReady = () => false;
+      const wallet = initializedWallets.get(walletId);
+      wallet.isReady = () => false;
+      wallet.state = HathorWallet.SYNCING;
 
       const response = await TestUtils.request
         .get('/health/wallet')
@@ -37,46 +172,86 @@ describe('healthcheck api', () => {
       expect(response.status).toBe(503);
 
       await TestUtils.stopWallet({ walletId });
-    })
+    });
   });
 
   describe('/health/fullnode', () => {
     it('should return 503 when the request to the fullnode fails', async () => {
-      const response = await TestUtils.request
-        .get('/health/fullnode');
-      expect(response.status).toBe(503);
-    })
+      TestUtils.httpMock.onGet('/version').networkError();
 
-    it('should return 503 when the fullnode resports as unhealthy', async () => {
       const response = await TestUtils.request
         .get('/health/fullnode');
+
       expect(response.status).toBe(503);
-    })
+      expect(response.body.status).toBe('fail');
+      expect(response.body.output).toBe('Error getting fullnode health: Network Error');
+      expect(response.body.componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.componentType).toBe('fullnode');
+    });
+
+    it('should return 503 when the fullnode reports as unhealthy', async () => {
+      TestUtils.httpMock.onGet('/version').reply(503, { status: 'fail' });
+
+      const response = await TestUtils.request
+        .get('/health/fullnode');
+
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.output).toBe('Fullnode reported as unhealthy: {"status":"fail"}');
+      expect(response.body.componentName).toBe('Fullnode http://fakehost:8083/v1a/');
+      expect(response.body.componentType).toBe('fullnode');
+    });
 
     it('should return 200 when the fullnode is ready', async () => {
       const response = await TestUtils.request
         .get('/health/fullnode');
       expect(response.status).toBe(200);
-    })
+      expect(response.body.status).toBe('pass');
+      expect(response.body.output).toBe('Fullnode is responding');
+    });
   });
 
   describe('/health/tx-mining-service', () => {
+    it('should return 503 when the tx mining service reports as unhealthy', async () => {
+      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
+        503,
+        { status: 'fail' }
+      );
+
+      const response = await TestUtils.request
+        .get('/health/tx-mining');
+      expect(response.status).toBe(503);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.output).toBe('Tx Mining Service reported as unhealthy: {"status":"fail"}');
+      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.componentType).toBe('service');
+    });
+
     it('should return 503 when the request to the tx mining service fails', async () => {
-      const response = await TestUtils.request
-        .get('/health/tx-mining-service');
-      expect(response.status).toBe(503);
-    })
+      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').networkErrorOnce();
 
-    it('should return 503 when the tx mining service resports as unhealthy', async () => {
       const response = await TestUtils.request
-        .get('/health/tx-mining-service');
+        .get('/health/tx-mining');
       expect(response.status).toBe(503);
-    })
+      expect(response.body.status).toBe('fail');
+      expect(response.body.output).toBe('Tx Mining Service reported as unhealthy: {"status":"fail"}');
+      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.componentType).toBe('service');
+    });
 
-    it('should return 200 when the tx mining service is ready', async () => {
+    it('should return 200 when the tx mining service is healthy', async () => {
+      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
+        200,
+        { status: 'pass' }
+      );
+
       const response = await TestUtils.request
-        .get('/health/tx-mining-service');
+        .get('/health/tx-mining');
       expect(response.status).toBe(200);
-    })
+      expect(response.body.status).toBe('pass');
+      expect(response.body.output).toBe('Tx Mining Service is healthy');
+      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
+      expect(response.body.componentType).toBe('service');
+    });
   });
 });

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -125,23 +125,6 @@ describe('healthcheck api', () => {
         .set({ 'x-wallet-ids': walletId })
         .get('/health');
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.description).toBe('Wallet-headless health');
-
-      expect(response.body.checks['Wallet health_wallet'][0].componentName).toBe('Wallet health_wallet');
-      expect(response.body.checks['Wallet health_wallet'][0].componentType).toBe('internal');
-      expect(response.body.checks['Wallet health_wallet'][0].output).toBe('Wallet is ready');
-      expect(response.body.checks['Wallet health_wallet'][0].status).toBe('pass');
-
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('fail');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode reported as unhealthy: {"status":"fail"}');
-
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
 
       expect(response.body).toStrictEqual({
         status: 'fail',

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -3,7 +3,7 @@ import TestUtils from './test-utils';
 
 const { initializedWallets } = require('../src/services/wallets.service');
 
-const walletId = "health_wallet"
+const walletId = 'health_wallet';
 
 describe('healthcheck api', () => {
   beforeAll(async () => {

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -50,11 +50,6 @@ describe('healthcheck api', () => {
     });
 
     it('should return 200 when all components are healthy', async () => {
-      TestUtils.httpMock.onGet('http://fake.txmining:8084/health').reply(
-        200,
-        { status: 'pass' }
-      );
-
       const response = await TestUtils.request
         .query({
           include_tx_mining: true,

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -29,23 +29,40 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health');
       expect(response.status).toBe(200);
-      expect(response.body.status).toBe('pass');
-      expect(response.body.description).toBe('Wallet-headless health');
 
-      expect(response.body.checks['Wallet health_wallet'][0].componentName).toBe('Wallet health_wallet');
-      expect(response.body.checks['Wallet health_wallet'][0].componentType).toBe('internal');
-      expect(response.body.checks['Wallet health_wallet'][0].status).toBe('pass');
-      expect(response.body.checks['Wallet health_wallet'][0].output).toBe('Wallet is ready');
-
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
-
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+      expect(response.body).toStrictEqual({
+        status: 'pass',
+        description: 'Wallet-headless health',
+        checks: {
+          'Wallet health_wallet': [
+            {
+              componentName: 'Wallet health_wallet',
+              componentType: 'internal',
+              status: 'pass',
+              output: 'Wallet is ready',
+              time: expect.any(String),
+            },
+          ],
+          'Fullnode http://fakehost:8083/v1a/': [
+            {
+              componentName: 'Fullnode http://fakehost:8083/v1a/',
+              componentType: 'fullnode',
+              status: 'pass',
+              output: 'Fullnode is responding',
+              time: expect.any(String),
+            },
+          ],
+          'TxMiningService http://fake.txmining:8084/': [
+            {
+              componentName: 'TxMiningService http://fake.txmining:8084/',
+              componentType: 'service',
+              status: 'pass',
+              output: 'Tx Mining Service is healthy',
+              time: expect.any(String),
+            },
+          ],
+        }
+      });
     });
 
     it('should return 503 when the wallet is not ready', async () => {
@@ -59,23 +76,40 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health');
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.description).toBe('Wallet-headless health');
 
-      expect(response.body.checks['Wallet health_wallet'][0].componentName).toBe('Wallet health_wallet');
-      expect(response.body.checks['Wallet health_wallet'][0].componentType).toBe('internal');
-      expect(response.body.checks['Wallet health_wallet'][0].status).toBe('fail');
-      expect(response.body.checks['Wallet health_wallet'][0].output).toBe('Wallet is not ready. Current state: Syncing');
-
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
-
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        description: 'Wallet-headless health',
+        checks: {
+          'Wallet health_wallet': [
+            {
+              componentName: 'Wallet health_wallet',
+              componentType: 'internal',
+              status: 'fail',
+              output: 'Wallet is not ready. Current state: Syncing',
+              time: expect.any(String),
+            },
+          ],
+          'Fullnode http://fakehost:8083/v1a/': [
+            {
+              componentName: 'Fullnode http://fakehost:8083/v1a/',
+              componentType: 'fullnode',
+              status: 'pass',
+              output: 'Fullnode is responding',
+              time: expect.any(String),
+            },
+          ],
+          'TxMiningService http://fake.txmining:8084/': [
+            {
+              componentName: 'TxMiningService http://fake.txmining:8084/',
+              componentType: 'service',
+              status: 'pass',
+              output: 'Tx Mining Service is healthy',
+              time: expect.any(String),
+            },
+          ],
+        }
+      });
 
       wallet.isReady = originalIsReady;
       wallet.state = originalState;
@@ -104,6 +138,40 @@ describe('healthcheck api', () => {
       expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
       expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('pass');
       expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service is healthy');
+
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        description: 'Wallet-headless health',
+        checks: {
+          'Wallet health_wallet': [
+            {
+              componentName: 'Wallet health_wallet',
+              componentType: 'internal',
+              status: 'pass',
+              output: 'Wallet is ready',
+              time: expect.any(String),
+            },
+          ],
+          'Fullnode http://fakehost:8083/v1a/': [
+            {
+              componentName: 'Fullnode http://fakehost:8083/v1a/',
+              componentType: 'fullnode',
+              status: 'fail',
+              output: 'Fullnode reported as unhealthy: {"status":"fail"}',
+              time: expect.any(String),
+            },
+          ],
+          'TxMiningService http://fake.txmining:8084/': [
+            {
+              componentName: 'TxMiningService http://fake.txmining:8084/',
+              componentType: 'service',
+              status: 'pass',
+              output: 'Tx Mining Service is healthy',
+              time: expect.any(String),
+            },
+          ],
+        }
+      });
     });
 
     it('should return 503 when the tx mining service is not healthy', async () => {
@@ -115,23 +183,40 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health');
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.description).toBe('Wallet-headless health');
 
-      expect(response.body.checks['Wallet health_wallet'][0].componentName).toBe('Wallet health_wallet');
-      expect(response.body.checks['Wallet health_wallet'][0].componentType).toBe('internal');
-      expect(response.body.checks['Wallet health_wallet'][0].output).toBe('Wallet is ready');
-      expect(response.body.checks['Wallet health_wallet'][0].status).toBe('pass');
-
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].componentType).toBe('fullnode');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].status).toBe('pass');
-      expect(response.body.checks['Fullnode http://fakehost:8083/v1a/'][0].output).toBe('Fullnode is responding');
-
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].componentType).toBe('service');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].status).toBe('fail');
-      expect(response.body.checks['TxMiningService http://fake.txmining:8084/'][0].output).toBe('Tx Mining Service reported as unhealthy: {"status":"fail"}');
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        description: 'Wallet-headless health',
+        checks: {
+          'Wallet health_wallet': [
+            {
+              componentName: 'Wallet health_wallet',
+              componentType: 'internal',
+              status: 'pass',
+              output: 'Wallet is ready',
+              time: expect.any(String),
+            },
+          ],
+          'Fullnode http://fakehost:8083/v1a/': [
+            {
+              componentName: 'Fullnode http://fakehost:8083/v1a/',
+              componentType: 'fullnode',
+              status: 'pass',
+              output: 'Fullnode is responding',
+              time: expect.any(String),
+            },
+          ],
+          'TxMiningService http://fake.txmining:8084/': [
+            {
+              componentName: 'TxMiningService http://fake.txmining:8084/',
+              componentType: 'service',
+              status: 'fail',
+              output: 'Tx Mining Service reported as unhealthy: {"status":"fail"}',
+              time: expect.any(String),
+            },
+          ],
+        }
+      });
     });
   });
 
@@ -141,16 +226,22 @@ describe('healthcheck api', () => {
         .get('/health/wallet')
         .set({ 'x-wallet-id': 'invalid-idl' });
       expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
-      expect(response.body.message).toBe('Invalid wallet id parameter.');
+
+      expect(response.body).toStrictEqual({
+        success: false,
+        message: 'Invalid wallet id parameter.',
+      });
     });
 
     it('should return 400 when the wallet has been started, but the header was not passed', async () => {
       const response = await TestUtils.request
         .get('/health/wallet');
       expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
-      expect(response.body.message).toBe('Header \'X-Wallet-Id\' is required.');
+
+      expect(response.body).toStrictEqual({
+        success: false,
+        message: 'Header \'X-Wallet-Id\' is required.',
+      });
     });
 
     it('should return 503 when the wallet is not ready', async () => {
@@ -178,10 +269,13 @@ describe('healthcheck api', () => {
         .get('/health/fullnode');
 
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.output).toBe('Error getting fullnode health: Network Error');
-      expect(response.body.componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.componentType).toBe('fullnode');
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        output: 'Error getting fullnode health: Network Error',
+        componentName: 'Fullnode http://fakehost:8083/v1a/',
+        componentType: 'fullnode',
+        time: expect.any(String),
+      });
     });
 
     it('should return 503 when the fullnode reports as unhealthy', async () => {
@@ -191,18 +285,28 @@ describe('healthcheck api', () => {
         .get('/health/fullnode');
 
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.output).toBe('Fullnode reported as unhealthy: {"status":"fail"}');
-      expect(response.body.componentName).toBe('Fullnode http://fakehost:8083/v1a/');
-      expect(response.body.componentType).toBe('fullnode');
+
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        output: 'Fullnode reported as unhealthy: {"status":"fail"}',
+        componentName: 'Fullnode http://fakehost:8083/v1a/',
+        componentType: 'fullnode',
+        time: expect.any(String),
+      });
     });
 
     it('should return 200 when the fullnode is ready', async () => {
       const response = await TestUtils.request
         .get('/health/fullnode');
       expect(response.status).toBe(200);
-      expect(response.body.status).toBe('pass');
-      expect(response.body.output).toBe('Fullnode is responding');
+
+      expect(response.body).toStrictEqual({
+        status: 'pass',
+        output: 'Fullnode is responding',
+        componentName: 'Fullnode http://fakehost:8083/v1a/',
+        componentType: 'fullnode',
+        time: expect.any(String),
+      });
     });
   });
 
@@ -216,10 +320,14 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health/tx-mining');
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.output).toBe('Tx Mining Service reported as unhealthy: {"status":"fail"}');
-      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.componentType).toBe('service');
+
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        output: 'Tx Mining Service reported as unhealthy: {"status":"fail"}',
+        componentName: 'TxMiningService http://fake.txmining:8084/',
+        componentType: 'service',
+        time: expect.any(String),
+      });
     });
 
     it('should return 503 when the request to the tx mining service fails', async () => {
@@ -228,10 +336,14 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health/tx-mining');
       expect(response.status).toBe(503);
-      expect(response.body.status).toBe('fail');
-      expect(response.body.output).toBe('Error getting tx-mining-service health: Network Error');
-      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.componentType).toBe('service');
+
+      expect(response.body).toStrictEqual({
+        status: 'fail',
+        output: 'Error getting tx-mining-service health: Network Error',
+        componentName: 'TxMiningService http://fake.txmining:8084/',
+        componentType: 'service',
+        time: expect.any(String),
+      });
     });
 
     it('should return 200 when the tx mining service is healthy', async () => {
@@ -243,10 +355,14 @@ describe('healthcheck api', () => {
       const response = await TestUtils.request
         .get('/health/tx-mining');
       expect(response.status).toBe(200);
-      expect(response.body.status).toBe('pass');
-      expect(response.body.output).toBe('Tx Mining Service is healthy');
-      expect(response.body.componentName).toBe('TxMiningService http://fake.txmining:8084/');
-      expect(response.body.componentType).toBe('service');
+
+      expect(response.body).toStrictEqual({
+        status: 'pass',
+        output: 'Tx Mining Service is healthy',
+        componentName: 'TxMiningService http://fake.txmining:8084/',
+        componentType: 'service',
+        time: expect.any(String),
+      });
     });
   });
 });

--- a/__tests__/healthcheck.test.js
+++ b/__tests__/healthcheck.test.js
@@ -29,7 +29,7 @@ describe('healthcheck api', () => {
   describe('/health', () => {
     it('should return 400 when the x-wallet-id is invalid', async () => {
       const response = await TestUtils.request
-        .query({ 'x-wallet-ids': 'invalid' })
+        .query({ wallet_ids: 'invalid' })
         .get('/health');
 
       expect(response.status).toBe(400);
@@ -57,9 +57,9 @@ describe('healthcheck api', () => {
 
       const response = await TestUtils.request
         .query({
-          'include-tx-mining': true,
-          'include-fullnode': true,
-          'x-wallet-ids': `${walletId},${anotherWalletId}`
+          include_tx_mining: true,
+          include_fullnode: true,
+          wallet_ids: `${walletId},${anotherWalletId}`
         })
         .get('/health');
       expect(response.status).toBe(200);
@@ -117,7 +117,7 @@ describe('healthcheck api', () => {
       wallet.state = HathorWallet.SYNCING;
 
       const response = await TestUtils.request
-        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
+        .query({ include_tx_mining: true, include_fullnode: true, wallet_ids: walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -163,7 +163,7 @@ describe('healthcheck api', () => {
       TestUtils.httpMock.onGet('/version').reply(503, { status: 'fail' });
 
       const response = await TestUtils.request
-        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
+        .query({ include_tx_mining: true, include_fullnode: true, wallet_ids: walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -209,7 +209,7 @@ describe('healthcheck api', () => {
       );
 
       const response = await TestUtils.request
-        .query({ 'include-tx-mining': true, 'include-fullnode': true, 'x-wallet-ids': walletId })
+        .query({ include_tx_mining: true, include_fullnode: true, wallet_ids: walletId })
         .get('/health');
       expect(response.status).toBe(503);
 
@@ -250,7 +250,7 @@ describe('healthcheck api', () => {
 
     it('should not include the fullnode when the parameter is missing', async () => {
       const response = await TestUtils.request
-        .query({ 'include-tx-mining': true, 'x-wallet-ids': walletId })
+        .query({ include_tx_mining: true, wallet_ids: walletId })
         .get('/health');
       expect(response.status).toBe(200);
 
@@ -282,7 +282,7 @@ describe('healthcheck api', () => {
 
     it('should not include the tx mining service when the parameter is missing', async () => {
       const response = await TestUtils.request
-        .query({ 'include-fullnode': true, 'x-wallet-ids': walletId })
+        .query({ include_fullnode: true, wallet_ids: walletId })
         .get('/health');
       expect(response.status).toBe(200);
 

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -208,6 +208,7 @@ class TestUtils {
     httpMock.onGet('/thin_wallet/token').reply(200, httpFixtures['/thin_wallet/token']);
     httpMock.onGet('/transaction').reply(200, httpFixtures['/transaction']);
     httpMock.onGet('/getmininginfo').reply(200, httpFixtures['/getmininginfo']);
+    httpMock.onGet('http://fake.txmining:8084/health').reply(200, httpFixtures['http://fake.txmining:8084/health']);
 
     // websocket mocks
     wsMock.on('connection', socket => {

--- a/__tests__/test-utils.js
+++ b/__tests__/test-utils.js
@@ -246,6 +246,12 @@ class TestUtils {
     });
   }
 
+  static resetRequest() {
+    // This can be used to reset the supertest agent and avoid interferences between tests,
+    // since everything is a singleton in this file
+    request = supertest.agent(server);
+  }
+
   static stopMocks() {
     httpMock.reset();
     server.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2638,7 +2638,7 @@
       "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.28.tgz",
       "integrity": "sha512-z4EB7r1JYqJCl31rpfm9qZX24tJ+PPvgAk7xvD6x8pqyv60j7hDTn1zt2mDQu0IxGlGMSnQmGmddZf3UcQXQ8w==",
       "requires": {
-        "bitcore-lib": "^8.25.47",
+        "bitcore-lib": "^8.25.28",
         "unorm": "^1.4.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,9 +2612,9 @@
       }
     },
     "bitcore-lib": {
-      "version": "8.25.28",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.28.tgz",
-      "integrity": "sha512-UrNHh0Ba8GUiHUYRmm2IKlb8eomsbvk/Z6oQdaOPQoLiamiKnu45pAMqtcHg06wMDF8at54oIdoD2WEU+TQujw==",
+      "version": "8.25.47",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.47.tgz",
+      "integrity": "sha512-qDZr42HuP4P02I8kMGZUx/vvwuDsz8X3rQxXLfM0BtKzlQBcbSM7ycDkDN99Xc5jzpd4fxNQyyFXOmc6owUsrQ==",
       "requires": {
         "bech32": "=2.0.0",
         "bip-schnorr": "=0.6.4",
@@ -2634,11 +2634,11 @@
       }
     },
     "bitcore-mnemonic": {
-      "version": "8.25.28",
-      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.28.tgz",
-      "integrity": "sha512-z4EB7r1JYqJCl31rpfm9qZX24tJ+PPvgAk7xvD6x8pqyv60j7hDTn1zt2mDQu0IxGlGMSnQmGmddZf3UcQXQ8w==",
+      "version": "8.25.47",
+      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.47.tgz",
+      "integrity": "sha512-wTa0imZZpFTqwlpyokvU8CNl+YdaIvQIrWKp/0AEL9gPX2vuzBnE+U8Ok6D5lHCnbG6dvmoesmtyf6R3aYI86A==",
       "requires": {
-        "bitcore-lib": "^8.25.28",
+        "bitcore-lib": "^8.25.47",
         "unorm": "^1.4.1"
       }
     },
@@ -4659,9 +4659,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -6756,9 +6756,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,9 +2612,9 @@
       }
     },
     "bitcore-lib": {
-      "version": "8.25.47",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.47.tgz",
-      "integrity": "sha512-qDZr42HuP4P02I8kMGZUx/vvwuDsz8X3rQxXLfM0BtKzlQBcbSM7ycDkDN99Xc5jzpd4fxNQyyFXOmc6owUsrQ==",
+      "version": "8.25.28",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.28.tgz",
+      "integrity": "sha512-UrNHh0Ba8GUiHUYRmm2IKlb8eomsbvk/Z6oQdaOPQoLiamiKnu45pAMqtcHg06wMDF8at54oIdoD2WEU+TQujw==",
       "requires": {
         "bech32": "=2.0.0",
         "bip-schnorr": "=0.6.4",
@@ -2634,9 +2634,9 @@
       }
     },
     "bitcore-mnemonic": {
-      "version": "8.25.47",
-      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.47.tgz",
-      "integrity": "sha512-wTa0imZZpFTqwlpyokvU8CNl+YdaIvQIrWKp/0AEL9gPX2vuzBnE+U8Ok6D5lHCnbG6dvmoesmtyf6R3aYI86A==",
+      "version": "8.25.28",
+      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.28.tgz",
+      "integrity": "sha512-z4EB7r1JYqJCl31rpfm9qZX24tJ+PPvgAk7xvD6x8pqyv60j7hDTn1zt2mDQu0IxGlGMSnQmGmddZf3UcQXQ8w==",
       "requires": {
         "bitcore-lib": "^8.25.47",
         "unorm": "^1.4.1"
@@ -4659,9 +4659,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -6756,9 +6756,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3841,18 +3841,18 @@ const defaultApiDocs = {
         summary: 'Return the health of the wallet headless.',
         parameters: [
           {
-            name: 'wallet-ids',
+            name: 'wallet_ids',
             in: 'query',
-            description: 'Define wallet ids to check, comma-separated. If not provided, will not check any wallet.',
+            description: 'Wallet ids to check, comma-separated. If not provided, will not check any wallet.',
             required: false,
             schema: {
               type: 'string',
             },
           },
           {
-            name: 'include-fullnode',
+            name: 'include_fullnode',
             in: 'query',
-            description: 'Define if fullnode health should be checked.',
+            description: 'Whether fullnode health should be checked and included in the response.',
             required: false,
             schema: {
               type: 'boolean',
@@ -3861,7 +3861,7 @@ const defaultApiDocs = {
           {
             name: 'include_tx_mining',
             in: 'query',
-            description: 'Define if tx mining service health should be checked.',
+            description: 'Whether tx mining service health should be checked and included in the response.',
             required: false,
             schema: {
               type: 'boolean',

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3836,6 +3836,243 @@ const defaultApiDocs = {
         },
       },
     },
+    '/health/wallet': {
+      get: {
+        summary: 'Return the health of a specific wallet.',
+        parameters: [
+          {
+            name: 'x-wallet-id',
+            in: 'header',
+            description: 'Define the corresponding wallet id whose health to check.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {
+                      status: 'pass',
+                      componentType: 'internal',
+                      componentName: 'Wallet <wallet-id>',
+                      output: 'Wallet is ready',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          503: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  unhealthy: {
+                    summary: 'Unhealthy wallet',
+                    value: {
+                      status: 'fail',
+                      componentType: 'internal',
+                      componentName: 'Wallet <wallet-id>',
+                      output: 'Wallet is not ready. Current state: <state>',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/health/fullnode': {
+      get: {
+        summary: 'Return the health of the fullnode.',
+        responses: {
+          200: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {
+                      status: 'pass',
+                      componentType: 'fullnode',
+                      componentName: 'Fullnode <fullnode_url>',
+                      output: 'Fullnode is responding',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          503: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  unhealthy: {
+                    summary: 'Unhealthy fullnode',
+                    value: {
+                      status: 'fail',
+                      componentType: 'internal',
+                      componentName: 'Fullnode',
+                      output: 'Fullnode reported as unhealthy: <fullnode response>',
+                    },
+                  },
+                  unreachable: {
+                    summary: 'Unreachable fullnode',
+                    value: {
+                      status: 'fail',
+                      componentType: 'internal',
+                      componentName: 'Fullnode',
+                      output: 'Error getting fullnode health: <error>',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/health/tx-mining': {
+      get: {
+        summary: 'Return the health of the tx mining service.',
+        responses: {
+          200: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {
+                      status: 'pass',
+                      componentType: 'service',
+                      componentName: 'TxMiningService <tx_mining_url>',
+                      output: 'Tx Mining Service is healthy',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          503: {
+            description: 'A JSON with the health object.',
+            content: {
+              'application/json': {
+                examples: {
+                  unhealthy: {
+                    summary: 'Unhealthy tx mining',
+                    value: {
+                      status: 'fail',
+                      componentType: 'service',
+                      componentName: 'TxMiningService <tx_mining_url>',
+                      output: 'Tx Mining Service reported as unhealthy: <tx mining response>',
+                    },
+                  },
+                  unreachable: {
+                    summary: 'Unreachable tx mining',
+                    value: {
+                      status: 'fail',
+                      componentType: 'service',
+                      componentName: 'TxMiningService <tx_mining_url>',
+                      output: 'Error getting tx-mining-service health: <error>',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/health': {
+      get: {
+        summary: 'Return the health of the wallet headless.',
+        responses: {
+          200: {
+            description: 'A JSON with the health object. It will contain info about all components that were checked.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {
+                      status: 'pass',
+                      description: 'Wallet-headless health',
+                      checks: {
+                        'Wallet <wallet-id>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id>',
+                          output: 'Wallet is ready',
+                        }],
+                        fullnode: [{
+                          status: 'pass',
+                          componentType: 'fullnode',
+                          componentName: 'Fullnode <fullnode_url>',
+                          output: 'Fullnode is responding',
+                        }],
+                        txMining: [{
+                          status: 'pass',
+                          componentType: 'service',
+                          componentName: 'TxMiningService <tx_mining_url>',
+                          output: 'Tx Mining Service is healthy',
+                        }]
+                      }
+                    },
+                  },
+                },
+              },
+            },
+          },
+          503: {
+            description: 'A JSON with the health object. It will contain info about all components that were checked.',
+            content: {
+              'application/json': {
+                examples: {
+                  unhealthy: {
+                    summary: 'Unhealthy wallet headless',
+                    value: {
+                      status: 'fail',
+                      description: 'Wallet-headless health',
+                      checks: {
+                        'Wallet <wallet-id>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id>',
+                          output: 'Wallet is ready',
+                        }],
+                        fullnode: [{
+                          status: 'fail',
+                          componentType: 'fullnode',
+                          componentName: 'Fullnode <fullnode_url>',
+                          output: 'Fullnode reported as unhealthy: <fullnode response>',
+                        }],
+                        txMining: [{
+                          status: 'pass',
+                          componentType: 'service',
+                          componentName: 'TxMiningService <tx_mining_url>',
+                          output: 'Tx Mining Service is healthy',
+                        }]
+                      }
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
 };
 

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3836,205 +3836,41 @@ const defaultApiDocs = {
         },
       },
     },
-    '/health/wallets': {
-      get: {
-        summary: 'Return the health of the provided wallets.',
-        parameters: [
-          {
-            name: 'x-wallet-ids',
-            in: 'header',
-            description: 'Define wallet ids to check, comma-separated.',
-            required: true,
-            schema: {
-              type: 'string',
-            },
-          },
-        ],
-        responses: {
-          200: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  success: {
-                    summary: 'Success',
-                    value: {
-                      status: 'pass',
-                      description: 'Wallet-headless health',
-                      checks: {
-                        'Wallet <wallet-id-1>': [{
-                          status: 'pass',
-                          componentType: 'internal',
-                          componentName: 'Wallet <wallet-id-1>',
-                          output: 'Wallet is ready',
-                        }],
-                        'Wallet <wallet-id-2>': [{
-                          status: 'pass',
-                          componentType: 'internal',
-                          componentName: 'Wallet <wallet-id-2>',
-                          output: 'Wallet is ready',
-                        }],
-                      }
-                    }
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  unhealthy: {
-                    summary: 'Unhealthy wallet',
-                    value: {
-                      status: 'fail',
-                      description: 'Wallet-headless health',
-                      checks: {
-                        'Wallet <wallet-id-1>': [{
-                          status: 'pass',
-                          componentType: 'internal',
-                          componentName: 'Wallet <wallet-id-1>',
-                          output: 'Wallet is ready',
-                        }],
-                        'Wallet <wallet-id-2>': [{
-                          status: 'fail',
-                          componentType: 'internal',
-                          componentName: 'Wallet <wallet-id-2>',
-                          output: 'Wallet is not ready. Current state: <state>',
-                        }],
-                      }
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/health/fullnode': {
-      get: {
-        summary: 'Return the health of the fullnode.',
-        responses: {
-          200: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  success: {
-                    summary: 'Success',
-                    value: {
-                      status: 'pass',
-                      componentType: 'fullnode',
-                      componentName: 'Fullnode <fullnode_url>',
-                      output: 'Fullnode is responding',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  unhealthy: {
-                    summary: 'Unhealthy fullnode',
-                    value: {
-                      status: 'fail',
-                      componentType: 'internal',
-                      componentName: 'Fullnode',
-                      output: 'Fullnode reported as unhealthy: <fullnode response>',
-                    },
-                  },
-                  unreachable: {
-                    summary: 'Unreachable fullnode',
-                    value: {
-                      status: 'fail',
-                      componentType: 'internal',
-                      componentName: 'Fullnode',
-                      output: 'Error getting fullnode health: <error>',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/health/tx-mining': {
-      get: {
-        summary: 'Return the health of the tx mining service.',
-        responses: {
-          200: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  success: {
-                    summary: 'Success',
-                    value: {
-                      status: 'pass',
-                      componentType: 'service',
-                      componentName: 'TxMiningService <tx_mining_url>',
-                      output: 'Tx Mining Service is healthy',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: 'A JSON with the health object.',
-            content: {
-              'application/json': {
-                examples: {
-                  unhealthy: {
-                    summary: 'Unhealthy tx mining',
-                    value: {
-                      status: 'fail',
-                      componentType: 'service',
-                      componentName: 'TxMiningService <tx_mining_url>',
-                      output: 'Tx Mining Service reported as unhealthy: <tx mining response>',
-                    },
-                  },
-                  unreachable: {
-                    summary: 'Unreachable tx mining',
-                    value: {
-                      status: 'fail',
-                      componentType: 'service',
-                      componentName: 'TxMiningService <tx_mining_url>',
-                      output: 'Error getting tx-mining-service health: <error>',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
     '/health': {
       get: {
         summary: 'Return the health of the wallet headless.',
         parameters: [
           {
             name: 'x-wallet-ids',
-            in: 'header',
-            description: 'Define wallet ids to check, comma-separated.',
-            required: true,
+            in: 'query',
+            description: 'Define wallet ids to check, comma-separated. If not provided, will not check any wallet.',
+            required: false,
             schema: {
               type: 'string',
             },
           },
+          {
+            name: 'include-fullnode',
+            in: 'query',
+            description: 'Define if fullnode health should be checked.',
+            required: false,
+            schema: {
+              type: 'boolean',
+            },
+          },
+          {
+            name: 'include-tx-mining',
+            in: 'query',
+            description: 'Define if tx mining service health should be checked.',
+            required: false,
+            schema: {
+              type: 'boolean',
+            },
+          }
         ],
         responses: {
           200: {
-            description: 'A JSON with the health object. It will contain info about all components and provided wallet ids.',
+            description: 'A JSON with the health object. It will contain info about all components that were enabled and provided wallet ids.',
             content: {
               'application/json': {
                 examples: {
@@ -4070,6 +3906,23 @@ const defaultApiDocs = {
                         }]
                       }
                     },
+                  },
+                },
+              },
+            },
+          },
+          400: {
+            description: 'A JSON object with the reason for the error.',
+            content: {
+              'application/json': {
+                examples: {
+                  'invalid-wallet-ids': {
+                    summary: 'Invalid wallet id',
+                    value: { success: false, message: 'Invalid wallet id parameter.' }
+                  },
+                  'no-component-included': {
+                    summary: 'No component was included in the request',
+                    value: { success: false, message: 'At least one component must be included in the health check' }
                   },
                 },
               },

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3836,14 +3836,14 @@ const defaultApiDocs = {
         },
       },
     },
-    '/health/wallet': {
+    '/health/wallets': {
       get: {
-        summary: 'Return the health of a specific wallet.',
+        summary: 'Return the health of the provided wallets.',
         parameters: [
           {
-            name: 'x-wallet-id',
+            name: 'x-wallet-ids',
             in: 'header',
-            description: 'Define the corresponding wallet id whose health to check.',
+            description: 'Define wallet ids to check, comma-separated.',
             required: true,
             schema: {
               type: 'string',
@@ -3860,10 +3860,22 @@ const defaultApiDocs = {
                     summary: 'Success',
                     value: {
                       status: 'pass',
-                      componentType: 'internal',
-                      componentName: 'Wallet <wallet-id>',
-                      output: 'Wallet is ready',
-                    },
+                      description: 'Wallet-headless health',
+                      checks: {
+                        'Wallet <wallet-id-1>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-1>',
+                          output: 'Wallet is ready',
+                        }],
+                        'Wallet <wallet-id-2>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-2>',
+                          output: 'Wallet is ready',
+                        }],
+                      }
+                    }
                   },
                 },
               },
@@ -3878,9 +3890,21 @@ const defaultApiDocs = {
                     summary: 'Unhealthy wallet',
                     value: {
                       status: 'fail',
-                      componentType: 'internal',
-                      componentName: 'Wallet <wallet-id>',
-                      output: 'Wallet is not ready. Current state: <state>',
+                      description: 'Wallet-headless health',
+                      checks: {
+                        'Wallet <wallet-id-1>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-1>',
+                          output: 'Wallet is ready',
+                        }],
+                        'Wallet <wallet-id-2>': [{
+                          status: 'fail',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-2>',
+                          output: 'Wallet is not ready. Current state: <state>',
+                        }],
+                      }
                     },
                   },
                 },
@@ -3997,9 +4021,20 @@ const defaultApiDocs = {
     '/health': {
       get: {
         summary: 'Return the health of the wallet headless.',
+        parameters: [
+          {
+            name: 'x-wallet-ids',
+            in: 'header',
+            description: 'Define wallet ids to check, comma-separated.',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
         responses: {
           200: {
-            description: 'A JSON with the health object. It will contain info about all components that were checked.',
+            description: 'A JSON with the health object. It will contain info about all components and provided wallet ids.',
             content: {
               'application/json': {
                 examples: {
@@ -4013,6 +4048,12 @@ const defaultApiDocs = {
                           status: 'pass',
                           componentType: 'internal',
                           componentName: 'Wallet <wallet-id>',
+                          output: 'Wallet is ready',
+                        }],
+                        'Wallet <wallet-id-2>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-2>',
                           output: 'Wallet is ready',
                         }],
                         fullnode: [{
@@ -4049,6 +4090,12 @@ const defaultApiDocs = {
                           status: 'pass',
                           componentType: 'internal',
                           componentName: 'Wallet <wallet-id>',
+                          output: 'Wallet is ready',
+                        }],
+                        'Wallet <wallet-id-2>': [{
+                          status: 'pass',
+                          componentType: 'internal',
+                          componentName: 'Wallet <wallet-id-2>',
                           output: 'Wallet is ready',
                         }],
                         fullnode: [{

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3841,7 +3841,7 @@ const defaultApiDocs = {
         summary: 'Return the health of the wallet headless.',
         parameters: [
           {
-            name: 'x-wallet-ids',
+            name: 'wallet-ids',
             in: 'query',
             description: 'Define wallet ids to check, comma-separated. If not provided, will not check any wallet.',
             required: false,
@@ -3859,7 +3859,7 @@ const defaultApiDocs = {
             },
           },
           {
-            name: 'include-tx-mining',
+            name: 'include_tx_mining',
             in: 'query',
             description: 'Define if tx mining service health should be checked.',
             required: false,

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -1,6 +1,7 @@
 import { buildServiceHealthCheck } from '../../helpers/healthcheck.helper';
 import { initializedWallets } from '../../services/wallets.service';
 import healthService from '../../services/healthcheck.service';
+import { parametersValidation } from '../../helpers/validations.helper';
 
 /**
  *
@@ -93,6 +94,12 @@ async function getWalletsHealthChecks(
  * the connected fullnode and the tx-mining-service
  */
 async function getGlobalHealth(req, res) {
+  const validationResult = parametersValidation(req);
+  if (!validationResult.success) {
+    res.status(400).json(validationResult);
+    return;
+  }
+
   const sendError = message => {
     res.status(400).send({
       success: false,

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -2,6 +2,54 @@ import { buildServiceHealthCheck } from '../../helpers/healthcheck.helper';
 import { initializedWallets } from '../../services/wallets.service';
 import healthService from '../../services/healthcheck.service';
 
+/**
+ *
+ * @param {string[]} walletIds
+ * @param {boolean} includeFullnode
+ * @param {boolean} includeTxMiningService
+ * @returns {Promise<{checks: Object, httpStatus: number, status: string}>}
+ * @private
+ * @description Returns the health checks for the given wallet ids. The fullnode and the
+ * tx-mining-service are optionally included in the checks, depending on the parameters.
+ *
+ * Also returns the http status code and the overall status of the health check.
+ *
+ * Returned object format:
+ *     {
+ *       httpStatus: 200,
+ *       status: 'pass',
+ *       checks: {
+ *        'Wallet health_wallet': [
+ *          {
+ *            componentName: 'Wallet health_wallet',
+ *            componentType: 'internal',
+ *            status: 'fail',
+ *            output: 'Wallet is not ready. Current state: Syncing',
+ *            time: expect.any(String),
+ *          },
+ *        ],
+ *        'Fullnode http://fakehost:8083/v1a/': [
+ *          {
+ *            componentName: 'Fullnode http://fakehost:8083/v1a/',
+ *            componentType: 'fullnode',
+ *            status: 'pass',
+ *            output: 'Fullnode is responding',
+ *            time: expect.any(String),
+ *          },
+ *        ],
+ *        'TxMiningService http://fake.txmining:8084/': [
+ *          {
+ *            componentName: 'TxMiningService http://fake.txmining:8084/',
+ *            componentType: 'service',
+ *            status: 'pass',
+ *            output: 'Tx Mining Service is healthy',
+ *            time: expect.any(String),
+ *          },
+ *        ],
+ *      }
+ *    }
+ *
+ */
 async function getWalletsHealthChecks(
   walletIds,
   includeFullnode = false,

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -2,39 +2,23 @@ import { buildServiceHealthCheck } from '../../helpers/healthcheck.helper';
 import { initializedWallets } from '../../services/wallets.service';
 import healthService from '../../services/healthcheck.service';
 
-/**
- * Controller for the /health endpoint that returns the health
- * of the wallet-headless service, including all started wallets,
- * the connected fullnode and the tx-mining-service
- */
-async function getGlobalHealth(req, res) {
-  const promises = [];
+async function getWalletsHealthChecks(
+  walletIds,
+  includeFullnode = false,
+  includeTxMiningService = false
+) {
+  const promises = Array.from(walletIds).map(
+    walletId => healthService.getWalletHealth(initializedWallets.get(walletId), walletId)
+  );
 
-  for (const [walletId, wallet] of initializedWallets) {
-    promises.push(healthService.getWalletHealth(wallet, walletId));
+  if (includeFullnode) {
+    promises.push(healthService.getFullnodeHealth());
+  }
+  if (includeTxMiningService) {
+    promises.push(healthService.getTxMiningServiceHealth());
   }
 
-  promises.push(healthService.getFullnodeHealth());
-  promises.push(healthService.getTxMiningServiceHealth());
-
-  // Use Promise.all to run all checks in parallel and replace the promises with the results
   const resolvedPromises = await Promise.all(promises);
-
-  let httpStatus = 200;
-  let status = 'pass';
-
-  for (const healthData of resolvedPromises) {
-    if (healthData.status === 'fail') {
-      httpStatus = 503;
-      status = 'fail';
-      break;
-    }
-
-    if (healthData.status === 'warn') {
-      httpStatus = 503;
-      status = 'warn';
-    }
-  }
 
   const checks = {};
 
@@ -43,6 +27,46 @@ async function getGlobalHealth(req, res) {
     // which allows us to add more checks to a component if needed
     checks[healthData.componentName] = [healthData];
   }
+
+  const httpStatus = resolvedPromises.every(healthData => healthData.status === 'pass') ? 200 : 503;
+  // If any of the checks failed, the status is fail. If all checks passed, the status is pass.
+  // Otherwise, the status is warn.
+  let status = httpStatus === 200 ? 'pass' : 'warn';
+  status = resolvedPromises.some(healthData => healthData.status === 'fail')
+    ? 'fail'
+    : status;
+
+  return { checks, httpStatus, status };
+}
+
+/**
+ * Controller for the /health endpoint that returns the health
+ * of the wallet-headless service, including all started wallets,
+ * the connected fullnode and the tx-mining-service
+ */
+async function getGlobalHealth(req, res) {
+  const sendError = message => {
+    res.status(400).send({
+      success: false,
+      message,
+    });
+  };
+
+  if (!('x-wallet-ids' in req.headers)) {
+    sendError('Header \'X-Wallet-Ids\' is required.');
+    return;
+  }
+
+  const walletIds = req.headers['x-wallet-ids'].split(',');
+
+  for (const walletId of walletIds) {
+    if (!initializedWallets.has(walletId)) {
+      sendError(`Invalid wallet id parameter: ${walletId}`);
+      return;
+    }
+  }
+
+  const { checks, httpStatus, status } = await getWalletsHealthChecks(walletIds, true, true);
 
   const serviceHealth = buildServiceHealthCheck(
     status,
@@ -57,7 +81,7 @@ async function getGlobalHealth(req, res) {
  * Controller for the /health/wallet endpoint that
  * returns the health of a specific wallet
  */
-async function getWalletHealth(req, res) {
+async function getWalletsHealth(req, res) {
   const sendError = message => {
     res.status(400).send({
       success: false,
@@ -65,22 +89,29 @@ async function getWalletHealth(req, res) {
     });
   };
 
-  if (!('x-wallet-id' in req.headers)) {
-    sendError('Header \'X-Wallet-Id\' is required.');
+  if (!('x-wallet-ids' in req.headers)) {
+    sendError('Header \'X-Wallet-Ids\' is required.');
     return;
   }
 
-  const walletId = req.headers['x-wallet-id'];
-  if (!initializedWallets.has(walletId)) {
-    sendError('Invalid wallet id parameter.');
-    return;
+  const walletIds = req.headers['x-wallet-ids'].split(',');
+
+  for (const walletId of walletIds) {
+    if (!initializedWallets.has(walletId)) {
+      sendError(`Invalid wallet id parameter: ${walletId}`);
+      return;
+    }
   }
-  const wallet = initializedWallets.get(walletId);
-  const walletHealthData = await healthService.getWalletHealth(wallet, walletId);
 
-  const status = walletHealthData.status === 'pass' ? 200 : 503;
+  const { checks, httpStatus, status } = await getWalletsHealthChecks(walletIds, true, true);
 
-  res.status(status).send(walletHealthData);
+  const serviceHealth = buildServiceHealthCheck(
+    status,
+    'Wallet-headless health',
+    checks,
+  );
+
+  res.status(httpStatus).send(serviceHealth);
 }
 
 /**
@@ -107,7 +138,7 @@ async function getTxMiningServiceHealth(req, res) {
 
 export {
   getGlobalHealth,
-  getWalletHealth,
+  getWalletsHealth,
   getFullnodeHealth,
   getTxMiningServiceHealth
 };

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -1,0 +1,96 @@
+import { buildServiceHealthCheck } from '../../helpers/healthcheck.helper';
+import { initializedWallets } from '../../services/wallets.service';
+import healthService from '../../services/healthcheck.service';
+
+async function getGlobalHealth(req, res) {
+  const promises = [];
+
+  for (const [walletId, wallet] of initializedWallets) {
+    promises.push(healthService.getWalletHealth(wallet, walletId));
+  }
+
+  promises.push(healthService.getFullnodeHealth());
+  promises.push(healthService.getTxMiningServiceHealth());
+
+  // Use Promise.all to run all checks in parallel and replace the promises with the results
+  const resolvedPromises = await Promise.all(promises);
+
+  let httpStatus = 200;
+  let status = 'pass';
+
+  for (const healthData of resolvedPromises) {
+    if (healthData.status === 'fail') {
+      httpStatus = 503;
+      status = 'fail';
+      break;
+    }
+
+    if (healthData.status === 'warn') {
+      httpStatus = 503;
+      status = 'warn';
+    }
+  }
+
+  const checks = {};
+
+  for (const healthData of resolvedPromises) {
+    // We use an array as the value to stick to our current format,
+    // which allows us to add more checks to a component if needed
+    checks[healthData.componentName] = [healthData];
+  }
+
+  const serviceHealth = buildServiceHealthCheck(
+    status,
+    'Wallet-headless health',
+    checks,
+  );
+
+  res.status(httpStatus).send(serviceHealth);
+}
+
+async function getWalletHealth(req, res) {
+  const sendError = message => {
+    res.status(400).send({
+      success: false,
+      message,
+    });
+  };
+
+  if (!('x-wallet-id' in req.headers)) {
+    sendError('Header \'X-Wallet-Id\' is required.');
+    return;
+  }
+
+  const walletId = req.headers['x-wallet-id'];
+  if (!initializedWallets.has(walletId)) {
+    sendError('Invalid wallet id parameter.');
+    return;
+  }
+  const wallet = initializedWallets.get(walletId);
+  const walletHealthData = await healthService.getWalletHealth(wallet, walletId);
+
+  const status = walletHealthData.status === 'pass' ? 200 : 503;
+
+  res.status(status).send(walletHealthData);
+}
+
+async function getFullnodeHealth(req, res) {
+  const fullnodeHealthData = await healthService.getFullnodeHealth();
+  const status = fullnodeHealthData.status === 'pass' ? 200 : 503;
+
+  res.status(status).send(fullnodeHealthData);
+}
+
+async function getTxMiningServiceHealth(req, res) {
+  const txMiningServiceHealthData = await healthService.getTxMiningServiceHealth();
+  const status = txMiningServiceHealthData.status === 'pass' ? 200 : 503;
+
+  res.status(status).send(txMiningServiceHealthData);
+}
+
+export {
+  getGlobalHealth,
+  getWalletHealth,
+  getFullnodeHealth,
+  getTxMiningServiceHealth
+};

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -103,7 +103,7 @@ async function getWalletsHealth(req, res) {
     }
   }
 
-  const { checks, httpStatus, status } = await getWalletsHealthChecks(walletIds, true, true);
+  const { checks, httpStatus, status } = await getWalletsHealthChecks(walletIds, false, false);
 
   const serviceHealth = buildServiceHealthCheck(
     status,

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -2,6 +2,11 @@ import { buildServiceHealthCheck } from '../../helpers/healthcheck.helper';
 import { initializedWallets } from '../../services/wallets.service';
 import healthService from '../../services/healthcheck.service';
 
+/**
+ * Controller for the /health endpoint that returns the health
+ * of the wallet-headless service, including all started wallets,
+ * the connected fullnode and the tx-mining-service
+ */
 async function getGlobalHealth(req, res) {
   const promises = [];
 
@@ -48,6 +53,10 @@ async function getGlobalHealth(req, res) {
   res.status(httpStatus).send(serviceHealth);
 }
 
+/**
+ * Controller for the /health/wallet endpoint that
+ * returns the health of a specific wallet
+ */
 async function getWalletHealth(req, res) {
   const sendError = message => {
     res.status(400).send({
@@ -74,6 +83,10 @@ async function getWalletHealth(req, res) {
   res.status(status).send(walletHealthData);
 }
 
+/**
+ * Controller for the /health/fullnode endpoint that
+ * returns the health of the connected fullnode
+ */
 async function getFullnodeHealth(req, res) {
   const fullnodeHealthData = await healthService.getFullnodeHealth();
   const status = fullnodeHealthData.status === 'pass' ? 200 : 503;
@@ -81,6 +94,10 @@ async function getFullnodeHealth(req, res) {
   res.status(status).send(fullnodeHealthData);
 }
 
+/**
+ * Controller for the /health/tx-mining endpoint that
+ * returns the health of the connected tx-mining-service
+ */
 async function getTxMiningServiceHealth(req, res) {
   const txMiningServiceHealthData = await healthService.getTxMiningServiceHealth();
   const status = txMiningServiceHealthData.status === 'pass' ? 200 : 503;

--- a/src/controllers/healthcheck/healthcheck.controller.js
+++ b/src/controllers/healthcheck/healthcheck.controller.js
@@ -102,8 +102,8 @@ async function getGlobalHealth(req, res) {
 
   let walletIds = [];
 
-  if ('x-wallet-ids' in req.query) {
-    walletIds = req.query['x-wallet-ids'].split(',');
+  if ('wallet_ids' in req.query) {
+    walletIds = req.query.wallet_ids.split(',');
   }
 
   for (const walletId of walletIds) {
@@ -113,8 +113,8 @@ async function getGlobalHealth(req, res) {
     }
   }
 
-  const includeFullnode = req.query['include-fullnode'] === 'true';
-  const includeTxMiningService = req.query['include-tx-mining'] === 'true';
+  const includeFullnode = req.query.include_fullnode === 'true';
+  const includeTxMiningService = req.query.include_tx_mining === 'true';
 
   // Check whether at least one component is included
   if (!includeFullnode && !includeTxMiningService && walletIds.length === 0) {

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -19,6 +19,7 @@ module.exports = {
     [HathorWallet.SYNCING]: 'Syncing',
     [HathorWallet.READY]: 'Ready',
     [HathorWallet.ERROR]: 'Error',
+    [HathorWallet.PROCESSING]: 'Processing',
   },
 
   // Error message when the user tries to send a transaction while the lock is active

--- a/src/helpers/healthcheck.helper.js
+++ b/src/helpers/healthcheck.helper.js
@@ -12,8 +12,8 @@ const ALLOWED_STATUSES = ['fail', 'pass', 'warn'];
  */
 export function buildComponentHealthCheck(componentName, status, componentType, output) {
   // Assert the component name is a string
-  if (typeof componentName !== 'string') {
-    throw new Error('Component name must be a string');
+  if (typeof componentName !== 'string' || componentName.length === 0) {
+    throw new Error('Component name must be a non-empty string');
   }
 
   // Assert the component type is one of the allowed values
@@ -27,8 +27,8 @@ export function buildComponentHealthCheck(componentName, status, componentType, 
   }
 
   // Assert the output is a string
-  if (typeof output !== 'string') {
-    throw new Error('Component output must be a string');
+  if (typeof output !== 'string' || output.length === 0) {
+    throw new Error('Component output must be a non-empty string');
   }
 
   // Build the health check object
@@ -51,8 +51,8 @@ export function buildComponentHealthCheck(componentName, status, componentType, 
  */
 export function buildServiceHealthCheck(status, description, checks) {
   // Assert the description is a string
-  if (typeof description !== 'string') {
-    throw new Error('Service description must be a string');
+  if (typeof description !== 'string' || description.length === 0) {
+    throw new Error('Service description must be a non-emtpy string');
   }
 
   // Assert the status is one of the allowed values

--- a/src/helpers/healthcheck.helper.js
+++ b/src/helpers/healthcheck.helper.js
@@ -44,6 +44,7 @@ export function buildComponentHealthCheck(componentName, status, componentType, 
 /**
  * Builds a health check object for a service.
  *
+ * @param {string} status
  * @param {string} description
  * @param {Object} checks
  * @returns {Object}
@@ -52,6 +53,11 @@ export function buildServiceHealthCheck(status, description, checks) {
   // Assert the description is a string
   if (typeof description !== 'string') {
     throw new Error('Service description must be a string');
+  }
+
+  // Assert the status is one of the allowed values
+  if (!ALLOWED_STATUSES.includes(status)) {
+    throw new Error(`Service status must be one of: ${ALLOWED_STATUSES.join(', ')}`);
   }
 
   return {

--- a/src/helpers/healthcheck.helper.js
+++ b/src/helpers/healthcheck.helper.js
@@ -52,7 +52,7 @@ export function buildComponentHealthCheck(componentName, status, componentType, 
 export function buildServiceHealthCheck(status, description, checks) {
   // Assert the description is a string
   if (typeof description !== 'string' || description.length === 0) {
-    throw new Error('Service description must be a non-emtpy string');
+    throw new Error('Service description must be a non-empty string');
   }
 
   // Assert the status is one of the allowed values

--- a/src/helpers/healthcheck.helper.js
+++ b/src/helpers/healthcheck.helper.js
@@ -1,0 +1,62 @@
+const ALLOWED_COMPONENT_TYPES = ['datastore', 'fullnode', 'internal', 'service'];
+const ALLOWED_STATUSES = ['fail', 'pass', 'warn'];
+
+/**
+ * Builds a health check object for a component
+ *
+ * @param {string} componentName
+ * @param {string} status
+ * @param {string} componentType
+ * @param {string} output
+ * @returns {Object}
+ */
+export function buildComponentHealthCheck(componentName, status, componentType, output) {
+  // Assert the component name is a string
+  if (typeof componentName !== 'string') {
+    throw new Error('Component name must be a string');
+  }
+
+  // Assert the component type is one of the allowed values
+  if (!ALLOWED_COMPONENT_TYPES.includes(componentType)) {
+    throw new Error(`Component status must be one of: ${ALLOWED_COMPONENT_TYPES.join(', ')}`);
+  }
+
+  // Assert the status is one of the allowed values
+  if (!ALLOWED_STATUSES.includes(status)) {
+    throw new Error(`Component status must be one of: ${ALLOWED_STATUSES.join(', ')}`);
+  }
+
+  // Assert the output is a string
+  if (typeof output !== 'string') {
+    throw new Error('Component output must be a string');
+  }
+
+  // Build the health check object
+  return {
+    componentName,
+    status,
+    componentType,
+    output,
+    time: new Date().toISOString(),
+  };
+}
+
+/**
+ * Builds a health check object for a service.
+ *
+ * @param {string} description
+ * @param {Object} checks
+ * @returns {Object}
+ */
+export function buildServiceHealthCheck(status, description, checks) {
+  // Assert the description is a string
+  if (typeof description !== 'string') {
+    throw new Error('Service description must be a string');
+  }
+
+  return {
+    status,
+    description,
+    checks,
+  };
+}

--- a/src/routes/healthcheck/healthcheck.routes.js
+++ b/src/routes/healthcheck/healthcheck.routes.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const { patchExpressRouter } = require('../../patch');
-const { getWalletHealth, getFullnodeHealth, getTxMiningServiceHealth, getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
+const { getWalletsHealth, getFullnodeHealth, getTxMiningServiceHealth, getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
 
 const healthcheckRouter = patchExpressRouter(Router({ mergeParams: true }));
 
@@ -14,7 +14,7 @@ healthcheckRouter.get('/', getGlobalHealth);
  * GET request to get the health of a wallet
  * For the docs, see api-docs.js
  */
-healthcheckRouter.get('/wallet', getWalletHealth);
+healthcheckRouter.get('/wallets', getWalletsHealth);
 
 /**
  * GET request to get the health of the fullnode

--- a/src/routes/healthcheck/healthcheck.routes.js
+++ b/src/routes/healthcheck/healthcheck.routes.js
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const { query } = require('express-validator');
 const { patchExpressRouter } = require('../../patch');
 const { getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
 
@@ -8,6 +9,12 @@ const healthcheckRouter = patchExpressRouter(Router({ mergeParams: true }));
  * GET request to get the health of the wallet-headless
  * For the docs, see api-docs.js
  */
-healthcheckRouter.get('/', getGlobalHealth);
+healthcheckRouter.get(
+  '/',
+  query('wallet_ids').isString().optional(),
+  query('include_fullnode').isBoolean().optional(),
+  query('include_tx_mining').isBoolean().optional(),
+  getGlobalHealth
+);
 
 module.exports = healthcheckRouter;

--- a/src/routes/healthcheck/healthcheck.routes.js
+++ b/src/routes/healthcheck/healthcheck.routes.js
@@ -1,0 +1,31 @@
+const { Router } = require('express');
+const { patchExpressRouter } = require('../../patch');
+const { getWalletHealth, getFullnodeHealth, getTxMiningServiceHealth, getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
+
+const healthcheckRouter = patchExpressRouter(Router({ mergeParams: true }));
+
+/**
+ * GET request to get the health of the wallet-headless
+ * For the docs, see api-docs.js
+ */
+healthcheckRouter.get('/', getGlobalHealth);
+
+/**
+ * GET request to get the health of a wallet
+ * For the docs, see api-docs.js
+ */
+healthcheckRouter.get('/wallet', getWalletHealth);
+
+/**
+ * GET request to get the health of the fullnode
+ * For the docs, see api-docs.js
+ */
+healthcheckRouter.get('/fullnode', getFullnodeHealth);
+
+/**
+ * GET request to get the health of the tx-mining-service
+ * For the docs, see api-docs.js
+ */
+healthcheckRouter.get('/tx-mining', getTxMiningServiceHealth);
+
+module.exports = healthcheckRouter;

--- a/src/routes/healthcheck/healthcheck.routes.js
+++ b/src/routes/healthcheck/healthcheck.routes.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const { patchExpressRouter } = require('../../patch');
-const { getWalletsHealth, getFullnodeHealth, getTxMiningServiceHealth, getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
+const { getGlobalHealth } = require('../../controllers/healthcheck/healthcheck.controller');
 
 const healthcheckRouter = patchExpressRouter(Router({ mergeParams: true }));
 
@@ -9,23 +9,5 @@ const healthcheckRouter = patchExpressRouter(Router({ mergeParams: true }));
  * For the docs, see api-docs.js
  */
 healthcheckRouter.get('/', getGlobalHealth);
-
-/**
- * GET request to get the health of a wallet
- * For the docs, see api-docs.js
- */
-healthcheckRouter.get('/wallets', getWalletsHealth);
-
-/**
- * GET request to get the health of the fullnode
- * For the docs, see api-docs.js
- */
-healthcheckRouter.get('/fullnode', getFullnodeHealth);
-
-/**
- * GET request to get the health of the tx-mining-service
- * For the docs, see api-docs.js
- */
-healthcheckRouter.get('/tx-mining', getTxMiningServiceHealth);
 
 module.exports = healthcheckRouter;

--- a/src/routes/index.routes.js
+++ b/src/routes/index.routes.js
@@ -13,6 +13,7 @@ const { patchExpressRouter } = require('../patch');
 
 const mainRouter = patchExpressRouter(Router({ mergeParams: true }));
 const walletRouter = require('./wallet/wallet.routes');
+const healthcheckRouter = require('./healthcheck/healthcheck.routes');
 
 mainRouter.get('/', rootControllers.welcome);
 mainRouter.get('/docs', rootControllers.docs);
@@ -37,5 +38,7 @@ mainRouter.get(
 mainRouter.post('/reload-config', rootControllers.reloadConfig);
 
 mainRouter.use('/wallet', walletRouter);
+
+mainRouter.use('/health', healthcheckRouter);
 
 module.exports = mainRouter;

--- a/src/services/healthcheck.service.js
+++ b/src/services/healthcheck.service.js
@@ -4,6 +4,13 @@ const { buildComponentHealthCheck } = require('../helpers/healthcheck.helper');
 const { friendlyWalletState } = require('../helpers/constants');
 
 const healthService = {
+  /**
+   * Returns the health object for a specific wallet
+   *
+   * @param {HathorWallet} wallet
+   * @param {string} walletId
+   * @returns {Object}
+   */
   async getWalletHealth(wallet, walletId) {
     let healthData;
 
@@ -26,6 +33,11 @@ const healthService = {
     return healthData;
   },
 
+  /**
+   * Returns the health object for the connected fullnode
+   *
+   * @returns {Object}
+   */
   async getFullnodeHealth() {
     let output;
     let healthStatus;
@@ -57,6 +69,11 @@ const healthService = {
     return fullnodeHealthData;
   },
 
+  /**
+   * Returns the health object for the connected tx-mining-service
+   *
+   * @returns {Object}
+   */
   async getTxMiningServiceHealth() {
     let output;
     let healthStatus;

--- a/src/services/healthcheck.service.js
+++ b/src/services/healthcheck.service.js
@@ -1,0 +1,95 @@
+import { config as hathorLibConfig, healthApi, txMiningApi } from '@hathor/wallet-lib';
+
+const { buildComponentHealthCheck } = require('../helpers/healthcheck.helper');
+const { friendlyWalletState } = require('../helpers/constants');
+
+const healthService = {
+  async getWalletHealth(wallet, walletId) {
+    let healthData;
+
+    if (!wallet.isReady()) {
+      healthData = buildComponentHealthCheck(
+        `Wallet ${walletId}`,
+        'fail',
+        'internal',
+        `Wallet is not ready. Current state: ${friendlyWalletState[wallet.state]}`
+      );
+    } else {
+      healthData = buildComponentHealthCheck(
+        `Wallet ${walletId}`,
+        'pass',
+        'internal',
+        'Wallet is ready'
+      );
+    }
+
+    return healthData;
+  },
+
+  async getFullnodeHealth() {
+    let output;
+    let healthStatus;
+
+    // TODO: We will need to parse the healthData to get the status,
+    // but hathor-core hasn't this implemented yet
+    try {
+      await healthApi.getHealth();
+
+      output = 'Fullnode is responding';
+      healthStatus = 'pass';
+    } catch (e) {
+      if (e.response && e.response.data) {
+        output = `Fullnode reported as unhealthy: ${JSON.stringify(e.response.data)}`;
+        healthStatus = e.response.data.status;
+      } else {
+        output = `Error getting fullnode health: ${e.message}`;
+        healthStatus = 'fail';
+      }
+    }
+
+    const fullnodeHealthData = buildComponentHealthCheck(
+      `Fullnode ${hathorLibConfig.getServerUrl()}`,
+      healthStatus,
+      'fullnode',
+      output
+    );
+
+    return fullnodeHealthData;
+  },
+
+  async getTxMiningServiceHealth() {
+    let output;
+    let healthStatus;
+
+    try {
+      const healthData = await txMiningApi.getHealth();
+
+      healthStatus = healthData.status;
+
+      if (healthStatus === 'fail') {
+        output = `Tx Mining Service reported as unhealthy: ${JSON.stringify(healthData)}`;
+      } else {
+        output = 'Tx Mining Service is healthy';
+      }
+    } catch (e) {
+      if (e.response && e.response.data) {
+        output = `Tx Mining Service reported as unhealthy: ${JSON.stringify(e.response.data)}`;
+        healthStatus = e.response.data.status;
+      } else {
+        output = `Error getting tx-mining-service health: ${e.message}`;
+        healthStatus = 'fail';
+      }
+    }
+
+    const txMiningServiceHealthData = buildComponentHealthCheck(
+      `TxMiningService ${hathorLibConfig.getTxMiningUrl()}`,
+      healthStatus,
+      'service',
+      output
+    );
+
+    return txMiningServiceHealthData;
+  }
+};
+
+export default healthService;


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-wallet-lib/pull/579

### Acceptance Criteria
- Create a new `/health` endpoint to return information about the health of the wallets and the connected components (tx-mining-service, hathor-core).

Note: There is an unfinished TODO because we are still developing a new `/health` endpoint on hathor-core as well. It will be solved in a future PR to use the new endpoint there when it's ready.

Note: The tests are failing because they depend on the wallet-lib changes.

### TODO
- [x] Bump the wallet-lib version after its next release


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
