### PR TITLE
chore: Pins Github action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # https://github.com/actions/checkout/releases/tag/v3.5.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        # https://github.com/github/codeql-action/releases/tag/codeql-bundle-v2.15.0
+        uses: github/codeql-action/init@517782a2a0dd93543ea4f12f41006cf70ddca135
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        # https://github.com/github/codeql-action/releases/tag/codeql-bundle-v2.15.0
+        uses: github/codeql-action/autobuild@517782a2a0dd93543ea4f12f41006cf70ddca135
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        # https://github.com/github/codeql-action/releases/tag/codeql-bundle-v2.15.0
+        uses: github/codeql-action/analyze@517782a2a0dd93543ea4f12f41006cf70ddca135
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      # https://github.com/actions/checkout/releases/tag/v3.5.0
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
     - name: Prepare tags
       id: tags
       run: |
@@ -20,22 +21,27 @@ jobs:
 
         python scripts/github/docker.py
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2  # we are trusting the action creator when using tags like this
+      # https://github.com/docker/setup-qemu-action/releases/tag/v2.2.0
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2  # we are trusting the action creator when using tags like this
+      # https://github.com/docker/setup-buildx-action/releases/tag/v2.10.0
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55
     - name: Login to DockerHub
-      uses: docker/login-action@v2  # we are trusting the action creator when using tags like this
+      # https://github.com/docker/login-action/releases/tag/v2.2.0
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to AWS ECR
-      uses: docker/login-action@v2  # we are trusting the action creator when using tags like this
+      # https://github.com/docker/login-action/releases/tag/v2.2.0
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
       with:
           registry: ${{ secrets.AWS_ECR_URL}}
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Build and push
-      uses: docker/build-push-action@v3  # we are trusting the action creator when using tags like this
+      # https://github.com/docker/build-push-action/releases/tag/v3.3.1
+      uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6
       with:
         push: true
         tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,10 +24,12 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      # https://github.com/actions/checkout/releases/tag/v2.7.0
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        # https://github.com/actions/setup-node/releases/tag/v1.4.6
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -39,14 +41,16 @@ jobs:
 
       - name: Upload debug transaction logs
         if: always()
-        uses: actions/upload-artifact@v2
+        # https://github.com/actions/upload-artifact/releases/tag/v2.3.1
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: test-transacion-logs
           path: tmp
 
       - name: Collect docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v1
+        # https://github.com/jwalton/gh-docker-logs/releases/tag/v1.0.0
+        uses: jwalton/gh-docker-logs@2a058a3b4c97aa3524391cb33bb5e917913ed676
         with:
           dest: './docker-logs'
       - name: Tar logs
@@ -54,7 +58,8 @@ jobs:
         run: tar cvzf ./docker-logs.tgz ./docker-logs
       - name: Upload logs to GitHub
         if: failure()
-        uses: actions/upload-artifact@v2
+        # https://github.com/actions/upload-artifact/releases/tag/v2.3.1
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
         with:
           name: logs.tgz
           path: ./docker-logs.tgz

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,11 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-      - uses: actions/checkout@v2
+      # https://github.com/actions/checkout/releases/tag/v2.7.0
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        # https://github.com/actions/setup-node/releases/tag/v1.4.6
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,11 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v2
+      # https://github.com/actions/checkout/releases/tag/v2.7.0
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        # https://github.com/actions/setup-node/releases/tag/v1.4.6
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -31,7 +33,8 @@ jobs:
       - name: Test
         run: npm run test
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        # https://github.com/codecov/codecov-action/releases/tag/v1.5.2
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
         if: ${{ matrix.node-version }} == 14.x
         with:
           verbose: true


### PR DESCRIPTION
### Acceptance Criteria
- All GitHub Actions dependencies should have their versions pinned


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
