### PR TITLE
tests: wait first block in integration tests to release genesis reward

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   TEST_WALLET_START_TIMEOUT: '180000'
+  TEST_WAIT_NEW_BLOCK_TIMEOUT: ${{ vars.TEST_WAIT_NEW_BLOCK_TIMEOUT }}
 
 jobs:
   itest:

--- a/__tests__/integration/configuration/test.config.js
+++ b/__tests__/integration/configuration/test.config.js
@@ -16,7 +16,6 @@ module.exports = {
   // Defines for how long the startMultipleWalletsForTest can run
   walletStartTimeout: process.env.TEST_WALLET_START_TIMEOUT || 300000,
 
-
   // This timeout is a protection, so the integration tests
   // don't keep running in case of a problem
   // After using the timeout as 120s, we had some timeouts

--- a/__tests__/integration/configuration/test.config.js
+++ b/__tests__/integration/configuration/test.config.js
@@ -15,4 +15,13 @@ module.exports = {
 
   // Defines for how long the startMultipleWalletsForTest can run
   walletStartTimeout: process.env.TEST_WALLET_START_TIMEOUT || 300000,
+
+
+  // This timeout is a protection, so the integration tests
+  // don't keep running in case of a problem
+  // After using the timeout as 120s, we had some timeouts
+  // because the CI runs in a free github runner
+  // so we decided to increase this timeout to 600s, so
+  // we don't have this error anymore
+  waitNewBlockTimeout: process.env.TEST_WAIT_NEW_BLOCK_TIMEOUT || 600000;
 };

--- a/__tests__/integration/configuration/test.config.js
+++ b/__tests__/integration/configuration/test.config.js
@@ -23,5 +23,5 @@ module.exports = {
   // because the CI runs in a free github runner
   // so we decided to increase this timeout to 600s, so
   // we don't have this error anymore
-  waitNewBlockTimeout: process.env.TEST_WAIT_NEW_BLOCK_TIMEOUT || 600000;
+  waitNewBlockTimeout: process.env.TEST_WAIT_NEW_BLOCK_TIMEOUT || 600000,
 };

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -802,7 +802,6 @@ export class TestUtils {
     // we don't have this error anymore
     const timeout = 600000;
     let timeoutReached = false;
-    // Timeout handler
     const timeoutHandler = setTimeout(() => {
       timeoutReached = true;
     }, timeout);
@@ -823,7 +822,6 @@ export class TestUtils {
       await delay(1000);
     }
 
-    // Clear timeout handler
     clearTimeout(timeoutHandler);
 
     if (timeoutReached) {

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -794,9 +794,6 @@ export class TestUtils {
   static async waitNewBlock(currentHeight = null) {
     let baseHeight = currentHeight;
 
-    console.log('WAIT NEW BLOCK');
-    console.log(testConfig.waitNewBlockTimeout);
-    console.log('------');
     const timeout = testConfig.waitNewBlockTimeout;
     let timeoutReached = false;
     const timeoutHandler = setTimeout(() => {

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -823,6 +823,10 @@ export class TestUtils {
       await delay(1000);
     }
 
+
+    // Clear timeout handler
+    clearTimeout(timeoutHandler);
+
     if (timeoutReached) {
       throw new Error('Timeout reached when waiting for the next block.');
     }

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -823,7 +823,6 @@ export class TestUtils {
       await delay(1000);
     }
 
-
     // Clear timeout handler
     clearTimeout(timeoutHandler);
 

--- a/__tests__/integration/utils/test-utils-integration.js
+++ b/__tests__/integration/utils/test-utils-integration.js
@@ -794,13 +794,10 @@ export class TestUtils {
   static async waitNewBlock(currentHeight = null) {
     let baseHeight = currentHeight;
 
-    // This timeout is a protection, so the integration tests
-    // don't keep running in case of a problem
-    // After using the timeout as 120s, we had some timeouts
-    // because the CI runs in a free github runner
-    // so we decided to increase this timeout to 600s, so
-    // we don't have this error anymore
-    const timeout = 600000;
+    console.log('WAIT NEW BLOCK');
+    console.log(testConfig.waitNewBlockTimeout);
+    console.log('------');
+    const timeout = testConfig.waitNewBlockTimeout;
     let timeoutReached = false;
     const timeoutHandler = setTimeout(() => {
       timeoutReached = true;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "yargs": "^16.2.0"
   },
   "scripts": {
-    "test": "jest --forceExit",
+    "test": "jest --forceExit  --runInBand",
     "test_integration": "npm run test_network_up && npm run test_network_integration && npm run test_network_down",
     "test_network_up": "docker-compose -f ./__tests__/integration/docker-compose.yml up -d && mkdir -p tmp && cp ./__tests__/integration/configuration/precalculated-wallets.json ./tmp/wallets.json",
     "test_network_integration": "jest --config jest-integration.config.js --runInBand --forceExit",

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -6,6 +6,7 @@ import { TxBenchmarkUtil } from './__tests__/integration/utils/benchmark/tx-benc
 import {
   precalculationHelpers, WalletPrecalculationHelper,
 } from './scripts/helpers/wallet-precalculation.helper';
+import { TestUtils } from './__tests__/integration/utils/test-utils-integration';
 
 expect.extend({
   toBeInArray(received, expected) {
@@ -86,6 +87,21 @@ beforeAll(async () => {
   // Loading pre-calculated wallets
   precalculationHelpers.test = new WalletPrecalculationHelper('./tmp/wallets.json');
   await precalculationHelpers.test.initWithWalletsFile();
+
+  // Await first block to be mined to release genesis reward lock
+  try {
+    await TestUtils.waitNewBlock();
+  } catch (err) {
+    // When running jest with jasmine there's a bug (or behavior)
+    // that any error thrown inside beforeAll methods don't stop the tests
+    // https://github.com/jestjs/jest/issues/2713
+    // The solution for that is to capture the error and call process.exit
+    // https://github.com/jestjs/jest/issues/2713#issuecomment-319822476
+    // The downside of that is that we don't get logs, however is the only
+    // way for now. We should stop using jasmine soon (and change for jest-circus)
+    // when we do some package upgrades
+    process.exit(1);
+  }
 });
 
 afterAll(async () => {


### PR DESCRIPTION
### Acceptance Criteria
- We must mine at least one block before starting the integration tests, so the genesis reward is unlocked.
- Add timeout in the method to wait for next block.
- The unit tests were running in parallel and they started to fail because of that. A deeper investigation on this matter must be done but in this PR I decided to just start running them serial, so everything is tested and works fine. A issue was created to handle this: https://github.com/HathorNetwork/hathor-wallet-headless/issues/355

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
