### PR TITLE
feat: add support for timelock in the send tx API

### DIFF
--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -624,7 +624,7 @@ describe('send tx (HTR)', () => {
     const addr0Info1 = await wallet1.getAddressInfo(0);
     expect(addr0Info1.total_amount_locked).toBe(0);
 
-    const timelock = parseInt(Date.now().valueOf() / 1000) + 1000; // timelock of 1,000 seconds
+    const timelock = parseInt(Date.now().valueOf() / 1000, 10) + 1000; // timelock of 1,000 seconds
     const tx = await wallet1.sendTx({
       fullObject: {
         outputs: [{

--- a/__tests__/integration/send-tx.test.js
+++ b/__tests__/integration/send-tx.test.js
@@ -619,6 +619,30 @@ describe('send tx (HTR)', () => {
       done();
     }
   );
+
+  it('should send with timelock', async done => {
+    const addr0Info1 = await wallet1.getAddressInfo(0);
+    expect(addr0Info1.total_amount_locked).toBe(0);
+
+    const timelock = parseInt(Date.now().valueOf() / 1000) + 1000; // timelock of 1,000 seconds
+    const tx = await wallet1.sendTx({
+      fullObject: {
+        outputs: [{
+          address: await wallet1.getAddressAt(0),
+          value: 100,
+          timelock
+        }],
+      },
+    });
+
+    expect(tx.success).toBe(true);
+    expect(tx.hash).toBeDefined();
+
+    const addr0Info2 = await wallet1.getAddressInfo(0);
+    expect(addr0Info2.total_amount_locked).toBe(100);
+
+    done();
+  });
 });
 
 describe('send tx (custom tokens)', () => {

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -2709,6 +2709,10 @@ const defaultApiDocs = {
                           type: 'string',
                           description: 'Data string of the data script output. Required if it\'s a data script output.'
                         },
+                        timelock: {
+                          type: 'integer',
+                          description: 'Timelock value for the output. Used only for P2PKH or P2SH.'
+                        },
                       }
                     },
                     description: 'Outputs to create the transaction.'

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -231,6 +231,16 @@ walletRouter.post(
       },
       optional: true
     },
+    'outputs.*.timelock': {
+      in: ['body'],
+      isInt: {
+        options: {
+          min: 1
+        }
+      },
+      toInt: true,
+      optional: true
+    },
     'outputs.*': {
       in: ['body'],
       isObject: true,


### PR DESCRIPTION
### Motivation

A use case needs to create transactions with timelock using the headless.

### Acceptance Criteria
- Add support for timelock in the `send-tx` API.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
