### PR TITLE
feat: Upload the api-docs on CI

### DIFF
--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # We use the config module to configure the apidocs generation
       - name: Create config module

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -81,5 +81,5 @@ jobs:
       # Copy the document to S3
       - name: Upload apidocs.json to S3
         run: |
-          aws s3 cp ./tmp/apidocs.json ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
+          aws s3 cp ./tmp/api-docs.json ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
       

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -21,9 +21,13 @@ jobs:
   
           if [[ "${{ github.ref }}" = refs/tags/* ]]; then
             version="${ref#refs/tags/}"
-            # This patterns accepts "v1.0.0" , "v2.4.6". Rejects "v1.0.0-rc1".
+
+            # Pattern that accepts "v1.0.0" , "v2.4.6". 
             if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               result=isRelease
+            # Pattern that accepts "v1.0.0-rc1".
+            elif [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+              result=isReleaseCandidate
             else
               result=isNotRelease
             fi
@@ -38,7 +42,9 @@ jobs:
   upload-apidocs:
     runs-on: ubuntu-22.04
     needs: check-version
-    if: ${{ needs.test_version.outputs.release_status_output == 'isRelease' }}
+    env:
+      release_status: ${{ needs.test_version.outputs.release_status_output }}
+    if: ${{ env.release_status == 'isRelease' || env.release_status == 'isReleaseCandidate' }}
     timeout-minutes: 10
 
     strategy:
@@ -83,5 +89,9 @@ jobs:
       # Copy the document to S3
       - name: Upload apidocs.json to S3
         run: |
-          aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
+          if [[ "${{ env.release_status }}" == "isReleaseCandidate" ]]; then
+            aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME_DEV }}
+          else
+            aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME_PROD }}
+          fi
       

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -49,8 +49,8 @@ jobs:
       # https://github.com/actions/checkout/releases/tag/v4.0.0
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Use Node.js ${{ matrix.node-version }}
-        # https://github.com/actions/setup-node/releases/tag/v3.8.1
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        # https://github.com/actions/setup-node/releases/tag/v4.0.0
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -9,7 +9,7 @@ jobs:
 
   # First check if this version is a valid public release
   check-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       release_status_output: ${{ steps.release_version.outputs.version_status_output }}
 
@@ -36,7 +36,7 @@ jobs:
 
   # Initiate upload only if the version is valid
   upload-apidocs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check-version
     if: ${{ needs.test_version.outputs.release_status_output == 'isRelease' }}
     timeout-minutes: 10

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -10,6 +10,8 @@ jobs:
   # First check if this version is a valid public release
   check-version:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write # This is required for requesting the JWT
     outputs:
       release_status_output: ${{ steps.release_version.outputs.version_status_output }}
 
@@ -89,8 +91,8 @@ jobs:
       - name: Upload apidocs.json to S3
         run: |
           if [[ "${{ env.release_status }}" == "isReleaseCandidate" ]]; then
-            aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME_DEV }}
+            aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_DEV }}
           else
-            aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME_PROD }}
+            aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_PROD }}
           fi
       

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -82,8 +82,7 @@ jobs:
         # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.1
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-assume-role: ${{ secrets.AWS_HEADLESS_UPLOAD_ROLE }}
           aws-region: us-east-1
 
       # Copy the document to S3

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -68,6 +68,8 @@ jobs:
         run: npm run docs_convert
       - name: Lint the apidocs json
         run: npm run docs_lint
+      - name: Build the apidocs HTML
+        run: npm run docs_build
 
       # Configure AWS credentials
       - name: Set up AWS CLI
@@ -81,5 +83,5 @@ jobs:
       # Copy the document to S3
       - name: Upload apidocs.json to S3
         run: |
-          aws s3 cp ./tmp/api-docs.json ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
+          aws s3 cp index.html ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
       

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -1,0 +1,85 @@
+name: apidocs
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  # First check if this version is a valid public release
+  check-version:
+    runs-on: ubuntu-20.04
+    outputs:
+      release_status_output: ${{ steps.release_version.outputs.version_status_output }}
+
+    steps:
+      - name: Check release version
+        id: release_version
+        shell: bash
+        run: |
+  
+          if [[ "${{ github.ref }}" = refs/tags/* ]]; then
+            version="${ref#refs/tags/}"
+            # This patterns accepts "v1.0.0" , "v2.4.6". Rejects "v1.0.0-rc1".
+            if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              result=isRelease
+            else
+              result=isNotRelease
+            fi
+          else
+            result=isNotTag
+          fi
+  
+          echo $result
+          echo "version_status_output=$result" >> $GITHUB_OUTPUT
+
+  # Initiate upload only if the version is valid
+  upload-apidocs:
+    runs-on: ubuntu-20.04
+    needs: check-version
+    if: ${{ needs.test_version.outputs.release_status_output == 'isRelease' }}
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.0.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Use Node.js ${{ matrix.node-version }}
+        # https://github.com/actions/setup-node/releases/tag/v3.8.1
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+
+      # We use the config module to configure the apidocs generation
+      - name: Create config module
+        run: cp ./config.js.template ./src/config.js
+
+      - name: Create the tmp folder
+        run: mkdir tmp
+
+      # Generating the apidocs json and linting to ensure it's a valid document
+      - name: Create the apidocs json
+        run: npm run docs_convert
+      - name: Lint the apidocs json
+        run: npm run docs_lint
+
+      # Configure AWS credentials
+      - name: Set up AWS CLI
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      # Copy the document to S3
+      - name: Upload apidocs.json to S3
+        run: |
+          aws s3 cp ./tmp/apidocs.json ${{ secrets.AWS_APIDOCS_BUCKET_NAME }}
+      

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "docs_lint": "npx @redocly/cli lint tmp/api-docs.json",
     "docs_server": "npx @redocly/cli preview-docs tmp/api-docs.json",
     "docs_clean": "rm tmp/api-docs.json",
+    "docs_build": "npx @redocly/cli build-docs tmp/api-docs.json -o index.html",
     "docs": "npm run docs_convert && npm run docs_lint && npm run docs_server && npm run docs_clean"
   },
   "repository": {


### PR DESCRIPTION
Finishes implementation of the [Api Docs CI](https://github.com/HathorNetwork/rfcs/blob/master/projects/hathor-wallet-headless/api-docs-ci.md) RFC.

When a commit on the `release` branch receives a valid version `tag`, this workflow automatically uploads the generated apidocs to the official apidocs website.

### Acceptance Criteria
- Automates the updating of the official [Headless Wallet apidocs](https://wallet-headless.docs.hathor.network/)

### Alternatives
Instead of creating a whole new workflow, we could have reused the existing `apidocs.yml` from #362 to generate the Api-Docs and lint them. The only steps left would be caching the results and uploading them to S3. The different approaches to this had some drawbacks:

##### Uploading on the same job
We could add the version validation to the `lint` job and upload the S3 right there. However this would make a `lint` job also have an eventual side-effect of changing our official documentation. This seemed like an obfuscated workflow that would raise yellow flags on future maintenance.

##### Creating a new job to upload
This would have a better separation of concerns for the jobs. However, every PR from now on would have a skipped job on its validations, except for the `release` ones. It is also a possibility that the action would not be executed on the `pull_request` trigger and would have to be manually re-run, which would make the automation criteria fail.