### PR TITLE
fix: Upload `api-docs` workflow

### DIFF
--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -12,8 +12,6 @@ jobs:
   # First check if this version is a valid public release
   check-version:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write # This is required for requesting the JWT
     outputs:
       release_status_output: ${{ steps.release_version.outputs.version_status_output }}
 
@@ -46,6 +44,8 @@ jobs:
   # Initiate upload only if the version is valid
   upload-apidocs:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write # This is required for requesting the JWT
     needs: check-version
     env:
       release_status: ${{ needs.test_version.outputs.release_status_output }}

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -94,9 +94,9 @@ jobs:
       # Copy the document to S3
       - name: Upload apidocs.json to S3
         run: |
-          if [[ "${{ env.release_status }}" == "isReleaseCandidate" ]]; then
-            aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_DEV }}
-          else
+          if [[ "${{ env.release_status }}" == "isRelease" ]]; then
             aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_PROD }}
+          else
+            aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_DEV }}
           fi
       

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - fix/apidocs-upload
 
 jobs:
 
@@ -23,6 +25,7 @@ jobs:
   
           if [[ "${{ github.ref }}" = refs/tags/* ]]; then
             version="${GITHUB_REF#refs/tags/}"
+            echo "version=$version"
 
             # Pattern that accepts "v1.0.0" , "v2.4.6". 
             if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -49,7 +52,8 @@ jobs:
     if: >-
       ${{ 
           needs.check-version.outputs.release_status_output == 'isRelease' || 
-          needs.check-version.outputs.release_status_output == 'isReleaseCandidate' 
+          needs.check-version.outputs.release_status_output == 'isReleaseCandidate' || 
+          needs.check-version.outputs.release_status_output == 'isNotTag' 
       }}
     timeout-minutes: 10
 

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -1,4 +1,4 @@
-name: apidocs
+name: apidocs-upload
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
         run: |
   
           if [[ "${{ github.ref }}" = refs/tags/* ]]; then
-            version="${ref#refs/tags/}"
+            version="${GITHUB_REF#refs/tags/}"
 
             # Pattern that accepts "v1.0.0" , "v2.4.6". 
             if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -46,7 +46,11 @@ jobs:
     needs: check-version
     env:
       release_status: ${{ needs.test_version.outputs.release_status_output }}
-    if: ${{ env.release_status == 'isRelease' || env.release_status == 'isReleaseCandidate' }}
+    if: >-
+      ${{ 
+          needs.check-version.outputs.release_status_output == 'isRelease' || 
+          needs.check-version.outputs.release_status_output == 'isReleaseCandidate' 
+      }}
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -92,7 +92,7 @@ jobs:
         # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.1
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a
         with:
-          aws-assume-role: ${{ secrets.AWS_HEADLESS_UPLOAD_ROLE }}
+          role-to-assume: ${{ secrets.AWS_HEADLESS_UPLOAD_ROLE }}
           aws-region: us-east-1
 
       # Copy the document to S3

--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - fix/apidocs-upload
 
 jobs:
 
@@ -52,8 +50,7 @@ jobs:
     if: >-
       ${{ 
           needs.check-version.outputs.release_status_output == 'isRelease' || 
-          needs.check-version.outputs.release_status_output == 'isReleaseCandidate' || 
-          needs.check-version.outputs.release_status_output == 'isNotTag' 
+          needs.check-version.outputs.release_status_output == 'isReleaseCandidate'
       }}
     timeout-minutes: 10
 


### PR DESCRIPTION
The `upload api-docs` script created on #364 had issues with the context of its environment variables not being accessible when needed.

### Acceptance Criteria
- Correctly uploads the `api-docs` to our documentation environment ( [evidence](https://github.com/HathorNetwork/hathor-wallet-headless/actions/runs/7467110975/job/20355501924) )

### Changelog
- Scope changed from `env` to `needs`, that is available inside an `if` clause
- Fixes the `ref` retrieval, obtaining it from a bash environment variable instead
- Changed workflow name to increase clarity on the GitHub actions tab
- Upload to `dev` by default, safeguarding the production environment


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
