### PR TITLE
fix: Docker env var type

### DIFF
--- a/config.js.docker
+++ b/config.js.docker
@@ -80,7 +80,7 @@ const config = {
   plugin_config: {},
 
   // Healthcheck configuration
-  considerHealthcheckWarnAsUnhealthy: getBooleanParam('consider_healthcheck_warn_as_unhealthy', true),
+  considerHealthcheckWarnAsUnhealthy: getBooleanParam('consider_healthcheck_warn_as_unhealthy', 'true'),
 };
 
 const seeds = getParam('seeds', 'default').split(' ');


### PR DESCRIPTION
### Acceptance Criteria
We shouldn't get the following error when running the Docker image (introduced in https://github.com/HathorNetwork/hathor-wallet-headless/pull/376):

```
/usr/src/app/dist/config.js:53
  throw new Error(`Invalid boolean parameter for ${name}. Received ${param}.`);
        ^

Error: Invalid boolean parameter for consider_healthcheck_warn_as_unhealthy. Received true.
    at getBooleanParam (/usr/src/app/dist/config.js:53:9)
    at Object.<anonymous> (/usr/src/app/dist/config.js:82:39)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at /usr/src/app/dist/settings.js:100:84
    at async _importConfig (/usr/src/app/dist/settings.js:100:11)
```


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
