### PR TITLE
tests: fix error when metadata of tx was still not updated

### DIFF
--- a/__tests__/integration/transaction.test.js
+++ b/__tests__/integration/transaction.test.js
@@ -73,7 +73,14 @@ describe('transaction routes', () => {
 
     let firstBlockHeight = txData1.meta.first_block_height;
     if (firstBlockHeight === null) {
+      // The idea here is to wait until the first_block_height metadata is filled in the transaction
+      // When a block is mined, the miner sends it to the full node and starts mining the new block
+      // from time to time, it updates the block template requesting the full node, maybe even
+      // getting new parents for the next block but if the mining succeeds fast, it won't have the
+      // new transactions as parents. That's why I'm waiting 2 blocks to guarantee the tx will be
+      // confirmed by at least one of them
       await TestUtils.waitNewBlock(height);
+      await TestUtils.waitNewBlock(height + 1);
       const txData2 = await TestUtils.getFullNodeTransactionData(txId);
       firstBlockHeight = txData2.meta.first_block_height;
       expect(firstBlockHeight).not.toBeNull();


### PR DESCRIPTION
### Motivation

We have frequently seen the error below in the confirmation blocks integration tests.

```
  ● transaction routes › test confirmation blocks

    expect(received).not.toBeNull()

    Received: null

      77 |       const txData2 = await TestUtils.getFullNodeTransactionData(txId);
      78 |       firstBlockHeight = txData2.meta.first_block_height;
    > 79 |       expect(firstBlockHeight).not.toBeNull();
         |                                    ^
      80 |     }
      81 |
      82 |     await TestUtils.waitNewBlock(firstBlockHeight);

      at Object.<anonymous> (__tests__/integration/transaction.test.js:79:36)
          at runMicrotasks (<anonymous>)
```

The best explanation is described in the code. A miner might be mining a new block really fast, then the block template is not updated with the new tx as a parent, so even with a new block, the tx is not confirmed. The solution used is to await two blocks to guarantee confirmation. It might not be the best solution but it's enough for an integration test.

### Acceptance Criteria
- Fix intermittent error in the confirmation blocks integration tests.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
