### PR TITLE
Refactor: Wallet Start service function

### DIFF
--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -222,7 +222,7 @@ async function start(req, res) {
     walletConfig.preCalculatedAddresses = preCalculatedAddresses;
   }
 
-  startWallet(walletID, walletConfig, config)
+  startWallet(walletID, walletConfig)
     .then(info => {
       res.send({
         success: true,

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -7,8 +7,7 @@
 
 const { walletApi, tokensUtils, walletUtils, Connection, HathorWallet, Network, helpersUtils, SendTransaction, constants: hathorLibConstants } = require('@hathor/wallet-lib');
 const { getApiDocs } = require('../api-docs');
-const { initializedWallets } = require('../services/wallets.service');
-const { notificationBus } = require('../services/notification.service');
+const { initializedWallets, startWallet } = require('../services/wallets.service');
 const { cantSendTxErrorMessage, API_ERROR_CODES } = require('../helpers/constants');
 const { parametersValidation } = require('../helpers/validations.helper');
 const { sanitizeLogInput } = require('../logger');
@@ -217,55 +216,25 @@ async function start(req, res) {
     }
   }
 
-  const connection = new Connection({
-    network: config.network,
-    servers: [config.server],
-    connectionTimeout: config.connectionTimeout,
-  });
-  walletConfig.connection = connection;
-
-  // tokenUid is optional but if not passed as parameter the wallet will use HTR
-  if (config.tokenUid) {
-    walletConfig.tokenUid = config.tokenUid;
-  }
-
   const preCalculatedAddresses = 'precalculatedAddresses' in req.body ? req.body.preCalculatedAddresses : [];
   if (preCalculatedAddresses && preCalculatedAddresses.length) {
     console.log(`Received pre-calculated addresses`, sanitizeLogInput(preCalculatedAddresses));
     walletConfig.preCalculatedAddresses = preCalculatedAddresses;
   }
 
-  const wallet = new HathorWallet(walletConfig);
-
-  if (config.gapLimit) {
-    // XXX: The gap limit is now a per-wallet configuration
-    // To keep the same behavior as before, we set the gap limit
-    // when creating the wallet, but we should move this to the
-    // wallet configuration in the future
-    await wallet.setGapLimit(config.gapLimit);
-  }
-
-  // subscribe to wallet events with notificationBus
-  notificationBus.subscribeHathorWallet(walletID, wallet);
-
-  wallet.start().then(info => {
-    // The replace avoids Log Injection
-    console.log(
-      `Wallet started with wallet id ${sanitizeLogInput(walletID)}. \
-Full-node info: ${JSON.stringify(info, null, 2)}`
-    );
-
-    initializedWallets.set(walletID, wallet);
-    res.send({
-      success: true,
+  startWallet(walletID, walletConfig, config)
+    .then(info => {
+      res.send({
+        success: true,
+      });
+    })
+    .catch(error => {
+      console.error('Error:', error);
+      res.send({
+        success: false,
+        message: `Failed to start wallet with wallet id ${walletID}`,
+      });
     });
-  }, error => {
-    console.error('Error:', error);
-    res.send({
-      success: false,
-      message: `Failed to start wallet with wallet id ${walletID}`,
-    });
-  });
 }
 
 function multisigPubkey(req, res) {

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { walletApi, tokensUtils, walletUtils, Connection, HathorWallet, Network, helpersUtils, SendTransaction, constants: hathorLibConstants } = require('@hathor/wallet-lib');
+const { walletApi, tokensUtils, walletUtils, Network, helpersUtils, SendTransaction, constants: hathorLibConstants } = require('@hathor/wallet-lib');
 const { getApiDocs } = require('../api-docs');
 const { initializedWallets, startWallet } = require('../services/wallets.service');
 const { cantSendTxErrorMessage, API_ERROR_CODES } = require('../helpers/constants');

--- a/src/helpers/wallet.helper.js
+++ b/src/helpers/wallet.helper.js
@@ -5,10 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { errors, walletUtils, config as hathorLibConfig } from '@hathor/wallet-lib';
+import { config as hathorLibConfig, errors, walletUtils } from '@hathor/wallet-lib';
 import { WalletStartError } from '../errors';
 import version from '../version';
 import { SWAP_SERVICE_MAINNET_BASE_URL, SWAP_SERVICE_TESTNET_BASE_URL } from '../constants';
+
+/**
+ * @typedef {object} WalletConfig
+ * @property {string} password - The password
+ * @property {string} pinCode - the PIN code
+ * @property {string} [xpub] - The xpub key (only in getReadonlyWalletConfig)
+ * @property {{ numSignatures: number, pubkeys: string[] }} [multisig] - The multisig data
+ * @property {{
+ *  policy: string,
+ *  startIndex?: number,
+ *  endIndex?: number,
+ *  gapLimit?: number,
+ * }} [scanPolicy] - Scan policy data
+ * @property {string} [seed] - The seed (only in getWalletConfigFromSeed)
+ * @property {string} [passphrase] - The passphrase (only in getWalletConfigFromSeed)
+ */
 
 export function initHathorLib(config) {
   if (config.txMiningUrl) {

--- a/src/services/wallets.service.js
+++ b/src/services/wallets.service.js
@@ -47,6 +47,18 @@ async function stopAllWallets() {
   }
 }
 
+/**
+ * Starts the wallet with the given configuration objects:
+ * one for the wallet instance and other for the application.
+ *
+ * Returns an object containing the fullnode version data.
+ *
+ * @param {string} walletId User identifier for the wallet
+ * @param {WalletConfig} walletConfig Wallet configuration
+ * @param {Configuration} config Application configuration
+ * @param {{}} [options={}] Additional options, currently unused
+ * @returns {Promise<Object>} Returns the fullnode version data
+ */
 async function startWallet(walletId, walletConfig, config, options = {}) {
   if (walletConfig.connection) {
     throw new Error('Invalid parameter for startWallet helper');

--- a/src/services/wallets.service.js
+++ b/src/services/wallets.service.js
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const { Connection, HathorWallet } = require('@hathor/wallet-lib');
 const { removeAllWalletProposals } = require('./atomic-swap.service');
+const { notificationBus } = require('./notification.service');
+const { sanitizeLogInput } = require('../logger');
 
 /**
  * @type {Map<string, HathorWallet>}
@@ -44,8 +47,49 @@ async function stopAllWallets() {
   }
 }
 
+async function startWallet(walletId, walletConfig, config, options = {}) {
+  if (walletConfig.connection) {
+    throw new Error('Invalid parameter for startWallet helper');
+  }
+  const hydratedWalletConfig = { ...walletConfig };
+
+  // Builds the connection object
+  hydratedWalletConfig.connection = new Connection({
+    network: config.network,
+    servers: [config.server],
+    connectionTimeout: config.connectionTimeout,
+  });
+
+  // tokenUid is optional but if not passed as parameter the wallet will use HTR
+  if (config.tokenUid) {
+    hydratedWalletConfig.tokenUid = config.tokenUid;
+  }
+
+  const wallet = new HathorWallet(hydratedWalletConfig);
+
+  if (config.gapLimit) {
+    // XXX: The gap limit is now a per-wallet configuration
+    // To keep the same behavior as before, we set the gap limit
+    // when creating the wallet, but we should move this to the
+    // wallet configuration in the future
+    await wallet.setGapLimit(config.gapLimit);
+  }
+
+  // subscribe to wallet events with notificationBus
+  notificationBus.subscribeHathorWallet(walletId, wallet);
+
+  const info = await wallet.start();
+  // The replace avoids Log Injection
+  console.log(`Wallet started with wallet id ${sanitizeLogInput(walletId)}. \
+Full-node info: ${JSON.stringify(info, null, 2)}`);
+
+  initializedWallets.set(walletId, wallet);
+  return info;
+}
+
 module.exports = {
   initializedWallets,
   stopWallet,
   stopAllWallets,
+  startWallet,
 };

--- a/src/services/wallets.service.js
+++ b/src/services/wallets.service.js
@@ -9,6 +9,7 @@ const { Connection, HathorWallet } = require('@hathor/wallet-lib');
 const { removeAllWalletProposals } = require('./atomic-swap.service');
 const { notificationBus } = require('./notification.service');
 const { sanitizeLogInput } = require('../logger');
+const settings = require('../settings');
 
 /**
  * @type {Map<string, HathorWallet>}
@@ -55,15 +56,15 @@ async function stopAllWallets() {
  *
  * @param {string} walletId User identifier for the wallet
  * @param {WalletConfig} walletConfig Wallet configuration
- * @param {Configuration} config Application configuration
  * @param {{}} [options={}] Additional options, currently unused
  * @returns {Promise<Object>} Returns the fullnode version data
  */
-async function startWallet(walletId, walletConfig, config, options = {}) {
+async function startWallet(walletId, walletConfig, options = {}) {
   if (walletConfig.connection) {
     throw new Error('Invalid parameter for startWallet helper');
   }
   const hydratedWalletConfig = { ...walletConfig };
+  const config = settings.getConfig();
 
   // Builds the connection object
   hydratedWalletConfig.connection = new Connection({


### PR DESCRIPTION
On the comment https://github.com/HathorNetwork/hathor-wallet-headless/pull/356#discussion_r1448223715 it was suggested that the wallet starting procedure should be centralized in a service function.

This PR extracts the wallet starting process so that it can be called from different conditions ( namely: HSM readonly wallets or conventional wallets ).

### Acceptance Criteria
- The wallet starting process should be extracted to a service function


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
