### PR TITLE
refactor: Moves default `pin` to constants

### DIFF
--- a/__tests__/__fixtures__/feature-fixture.js
+++ b/__tests__/__fixtures__/feature-fixture.js
@@ -3,6 +3,9 @@ const constants = {
 
   SWAP_SERVICE_MAINNET_BASE_URL: 'https://atomic-swap-service.mainnet.mock/',
   SWAP_SERVICE_TESTNET_BASE_URL: 'https://atomic-swap-service.testnet.mock/',
+
+  DEFAULT_PASSWORD: '123',
+  DEFAULT_PIN: '123',
 };
 
 // Allow change config at runtime

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,4 +12,7 @@ module.exports = {
   SWAP_SERVICE_FEATURE_TOGGLE: false,
   SWAP_SERVICE_MAINNET_BASE_URL: 'https://atomic-swap-service.hathor.network/',
   SWAP_SERVICE_TESTNET_BASE_URL: 'https://atomic-swap-service.testnet.hathor.network/',
+
+  DEFAULT_PASSWORD: '123',
+  DEFAULT_PIN: '123',
 };

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -239,7 +239,7 @@ async function getMySignatures(req, res) {
 
   try {
     const proposal = PartialTxProposal.fromPartialTx(partialTx, req.wallet.storage);
-    await proposal.signData('123');
+    await proposal.signData(constants.DEFAULT_PIN);
     res.send({
       success: true,
       signatures: proposal.signatures.serialize(),

--- a/src/controllers/wallet/p2sh/tx-proposal.controller.js
+++ b/src/controllers/wallet/p2sh/tx-proposal.controller.js
@@ -15,6 +15,7 @@ const { parametersValidation } = require('../../../helpers/validations.helper');
 const { lock, lockTypes } = require('../../../lock');
 const { cantSendTxErrorMessage } = require('../../../helpers/constants');
 const { mapTxReturn } = require('../../../helpers/tx.helper');
+const { DEFAULT_PIN } = require('../../../constants');
 
 async function buildTxProposal(req, res) {
   const validationResult = parametersValidation(req);
@@ -188,7 +189,7 @@ async function getMySignatures(req, res) {
 
   const { txHex } = req.body;
   try {
-    const sigs = await req.wallet.getAllSignatures(txHex, '123');
+    const sigs = await req.wallet.getAllSignatures(txHex, DEFAULT_PIN);
     res.send({ success: true, signatures: sigs });
   } catch (err) {
     res.send({ success: false, error: err.message });

--- a/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
+++ b/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
@@ -14,6 +14,7 @@ const {
 const { _ } = require('lodash');
 const { prepareTxFunds } = require('../../../helpers/tx.helper');
 const { parametersValidation } = require('../../../helpers/validations.helper');
+const { DEFAULT_PIN } = require('../../../constants');
 
 async function buildTxProposal(req, res) {
   const validationResult = parametersValidation(req);
@@ -46,7 +47,7 @@ async function buildTxProposal(req, res) {
       outputs,
       inputs,
       changeAddress,
-      pin: '123',
+      pin: DEFAULT_PIN,
     });
     const fullTxData = await sendTransaction.prepareTxData();
     // Do not sign or complete the transaction yet

--- a/src/helpers/wallet.helper.js
+++ b/src/helpers/wallet.helper.js
@@ -8,7 +8,9 @@
 import { config as hathorLibConfig, errors, walletUtils } from '@hathor/wallet-lib';
 import { WalletStartError } from '../errors';
 import version from '../version';
-import { SWAP_SERVICE_MAINNET_BASE_URL, SWAP_SERVICE_TESTNET_BASE_URL } from '../constants';
+import {
+  DEFAULT_PASSWORD, DEFAULT_PIN, SWAP_SERVICE_MAINNET_BASE_URL, SWAP_SERVICE_TESTNET_BASE_URL,
+} from '../constants';
 
 /**
  * @typedef {object} WalletConfig
@@ -66,8 +68,8 @@ export function getReadonlyWalletConfig({
   // We currently need something to be defined, otherwise we get an error when starting the wallet
   const walletConfig = {
     xpub,
-    password: '123',
-    pinCode: '123',
+    password: DEFAULT_PASSWORD,
+    pinCode: DEFAULT_PIN,
     multisig: multisigData,
     scanPolicy,
   };
@@ -99,8 +101,8 @@ export function getWalletConfigFromSeed({
   // We currently need something to be defined, otherwise we get an error when starting the wallet
   const walletConfig = {
     seed: words,
-    password: '123',
-    pinCode: '123',
+    password: DEFAULT_PASSWORD,
+    pinCode: DEFAULT_PIN,
     multisig: multisigData,
     scanPolicy,
   };


### PR DESCRIPTION
Closes #246 

### Acceptance Criteria
- Moves the default `pin` and `password` hardcoded strings to the `constants.js` file


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
