### PR TITLE
fix: HTML upload for release environment

### DIFF
--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -46,7 +46,7 @@ jobs:
       id-token: write # This is required for requesting the JWT
     needs: check-version
     env:
-      release_status: ${{ needs.test_version.outputs.release_status_output }}
+      release_status: ${{ needs.check-version.outputs.release_status_output }}
     if: >-
       ${{ 
           needs.check-version.outputs.release_status_output == 'isRelease' || 
@@ -93,7 +93,7 @@ jobs:
           aws-region: us-east-1
 
       # Copy the document to S3
-      - name: Upload apidocs.json to S3
+      - name: Upload HTML to S3
         run: |
           if [[ "${{ env.release_status }}" == "isRelease" ]]; then
             aws s3 cp index.html s3://${{ secrets.AWS_APIDOCS_BUCKET_NAME_PROD }}


### PR DESCRIPTION
The environment variable for the _upload_ step was being retrieved from the incorrect source.

### Acceptance Criteria
- Fixes the api-docs HTML upload for official releases


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
