### PR TITLE
fix: Release candidate regex

### DIFF
--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -8,6 +8,8 @@ on:
 jobs:
 
   # First check if this version is a valid public release
+  # This follows semver recommendations, with release candidates having a dash and a dot
+  # @see https://semver.org/spec/v2.0.0-rc.2.html
   check-version:
     runs-on: ubuntu-22.04
     outputs:
@@ -27,7 +29,7 @@ jobs:
             if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               result=isRelease
             # Pattern that accepts "v1.0.0-rc1".
-            elif [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            elif [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
               result=isReleaseCandidate
             else
               result=isNotRelease


### PR DESCRIPTION
### Acceptance Criteria
- The release candidate regex should require a dot after the dash, as of `vX.Y.Z-rc.N` instead of `vX.Y.Z-rcN`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
