### PR TITLE
fix: add codecov token in secret to do codecov upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Test
         run: npm run test
       - name: Upload coverage
-        # https://github.com/codecov/codecov-action/releases/tag/v1.5.2
-        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
-        if: ${{ matrix.node-version }} == 14.x
-        with:
-          verbose: true
+        # https://github.com/codecov/codecov-action/releases/tag/v4.3.0
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation

Codecov's upload task on CI broke, it used to be unstable so we suspected that was the case but apparently it is now required to use a token.

### Acceptance Criteria

- Add a secret token to the repo's settings
- Add CI config to expose the token to codecov's upload task


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
