### PR TITLE
chore: configure fireblocks secret in docker

### DIFF
--- a/config.js.docker
+++ b/config.js.docker
@@ -1,3 +1,4 @@
+import 'fs';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -65,7 +66,6 @@ const config = {
 
   fireblocksUrl: getParam('fireblocks_url', 'https://api.fireblocks.io'),
   fireblocksApiKey: getParam('fireblocks_api_key'),
-  fireblocksApiSecret: getParam('fireblocks_api_secret'),
 
   http_api_key: getParam('api_key'),
   httpLogFormat: getParam('http_log_format'),
@@ -140,6 +140,11 @@ if (debugPath) {
     filename: debugPath,
     level: 'debug',
   };
+}
+
+const fireblocksApiSecretFile = getParam('fireblocks_api_secret');
+if (fireblocksApiSecretFile) {
+  config.fireblocksApiSecret = fs.readFileSync(fireblocksApiSecretFile);
 }
 
 module.exports = config;

--- a/config.js.docker
+++ b/config.js.docker
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -66,6 +65,8 @@ const config = {
 
   fireblocksUrl: getParam('fireblocks_url', 'https://api.fireblocks.io'),
   fireblocksApiKey: getParam('fireblocks_api_key'),
+  fireblocksApiSecret: getParam('fireblocks_api_secret'),
+  fireblocksApiSecretFile: getParam('fireblocks_api_secret_file'),
 
   http_api_key: getParam('api_key'),
   httpLogFormat: getParam('http_log_format'),
@@ -140,17 +141,6 @@ if (debugPath) {
     filename: debugPath,
     level: 'debug',
   };
-}
-
-const fireblocksApiSecret = getParam('fireblocks_api_secret');
-if (fireblocksApiSecret) {
-  console.warn('[WARNING] fireblocks_api_secret is disabled for docker. Use fireblocks_api_secret_file instead.');
-  throw new Error('[WARNING] fireblocks_api_secret is disabled for docker. Use fireblocks_api_secret_file instead.');
-}
-
-const fireblocksApiSecretFile = getParam('fireblocks_api_secret_file');
-if (fireblocksApiSecretFile) {
-  config.fireblocksApiSecret = fs.readFileSync(fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
 }
 
 module.exports = config;

--- a/config.js.docker
+++ b/config.js.docker
@@ -142,7 +142,7 @@ if (debugPath) {
   };
 }
 
-const fireblocksApiSecretFile = getParam('fireblocks_api_secret');
+const fireblocksApiSecretFile = getParam('fireblocks_api_secret_file');
 if (fireblocksApiSecretFile) {
   config.fireblocksApiSecret = fs.readFileSync(fireblocksApiSecretFile);
 }

--- a/config.js.docker
+++ b/config.js.docker
@@ -143,4 +143,11 @@ if (debugPath) {
   };
 }
 
+const fireblocksApiSecret = getParam('fireblocks_api_secret');
+if (fireblocksApiSecret) {
+  const warnMessage = '[WARNING] fireblocks_api_secret is disabled for docker. Use fireblocks_api_secret_file instead.';
+  console.warn(warnMessage);
+  throw new Error(warnMessage);
+}
+
 module.exports = config;

--- a/config.js.docker
+++ b/config.js.docker
@@ -1,4 +1,4 @@
-import 'fs';
+import fs from 'fs';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -142,9 +142,15 @@ if (debugPath) {
   };
 }
 
+const fireblocksApiSecret = getParam('fireblocks_api_secret');
+if (fireblocksApiSecret) {
+  console.warn('[WARNING] fireblocks_api_secret is disabled for docker. Use fireblocks_api_secret_file instead.');
+  throw new Error('[WARNING] fireblocks_api_secret is disabled for docker. Use fireblocks_api_secret_file instead.');
+}
+
 const fireblocksApiSecretFile = getParam('fireblocks_api_secret_file');
 if (fireblocksApiSecretFile) {
-  config.fireblocksApiSecret = fs.readFileSync(fireblocksApiSecretFile);
+  config.fireblocksApiSecret = fs.readFileSync(fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
 }
 
 module.exports = config;

--- a/config.js.template
+++ b/config.js.template
@@ -1,6 +1,4 @@
-import fs from 'fs';
-
-const config = {
+module.exports = {
   // HTTP API Settings
   http_bind_address: 'localhost',
   http_port: 8000,
@@ -109,9 +107,3 @@ const config = {
   // Check the /health endpoint documentation for more info.
   considerHealthcheckWarnAsUnhealthy: true,
 };
-
-if (config.fireblocksApiSecretFile && fs.existsSync(config.fireblocksApiSecretFile)) {
-  config.fireblocksApiSecret = fs.readFileSync(config.fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
-}
-
-module.exports = config;

--- a/config.js.template
+++ b/config.js.template
@@ -1,4 +1,6 @@
-module.exports = {
+import fs from 'fs';
+
+const config = {
   // HTTP API Settings
   http_bind_address: 'localhost',
   http_port: 8000,
@@ -26,9 +28,13 @@ module.exports = {
   hsmUsername: null,
   hsmPassword: null,
 
+  // Only change the URL if you want to use the Sandbox API under 'https://sandbox-api.fireblocks.io'
   fireblocksUrl: 'https://api.fireblocks.io',
   fireblocksApiKey: null,
+  // This should be a string containing the secret (with line breaks)
   fireblocksApiSecret: null,
+  // This supercedes the fireblocksApiKey if both are set
+  fireblocksApiSecretFile: null,
 
   // ApiKey to use with Tx Mining Service
   // This is optional. You should set it only if you have an api-key.
@@ -103,3 +109,9 @@ module.exports = {
   // Check the /health endpoint documentation for more info.
   considerHealthcheckWarnAsUnhealthy: true,
 };
+
+if (config.fireblocksApiSecretFile && fs.existsSync(config.fireblocksApiSecretFile)) {
+  config.fireblocksApiSecret = fs.readFileSync(config.fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
+}
+
+module.exports = config;

--- a/src/controllers/fireblocks/fireblocks.controller.js
+++ b/src/controllers/fireblocks/fireblocks.controller.js
@@ -60,7 +60,7 @@ async function startFireblocksWallet(req, res) {
   const config = settings.getConfig();
 
   // Validate login data for fireblocks.
-  if (!(config.fireblocksUrl && config.fireblocksApiKey && config.fireblocksApiSecret)) {
+  if (!(config.fireblocksUrl && config.fireblocksApiKey && (config.fireblocksApiSecret || config.fireblocksApiSecretFile))) {
     console.error('Error starting wallet because fireblocks is not configured.');
     res.send({
       success: false,
@@ -102,7 +102,7 @@ async function startFireblocksWallet(req, res) {
   const walletConfig = getReadonlyWalletConfig({ xpub });
 
   try {
-    await startWallet(walletId, walletConfig, config, { });
+    await startWallet(walletId, walletConfig, config);
 
     const wallet = initializedWallets.get(walletId);
     // When signing transactions, the wallet will use this function

--- a/src/controllers/fireblocks/fireblocks.controller.js
+++ b/src/controllers/fireblocks/fireblocks.controller.js
@@ -60,7 +60,9 @@ async function startFireblocksWallet(req, res) {
   const config = settings.getConfig();
 
   // Validate login data for fireblocks.
-  if (!(config.fireblocksUrl && config.fireblocksApiKey && (config.fireblocksApiSecret || config.fireblocksApiSecretFile))) {
+  if (!(config.fireblocksUrl
+        && config.fireblocksApiKey
+        && (config.fireblocksApiSecret || config.fireblocksApiSecretFile))) {
     console.error('Error starting wallet because fireblocks is not configured.');
     res.send({
       success: false,

--- a/src/services/fireblocks.service.js
+++ b/src/services/fireblocks.service.js
@@ -346,7 +346,7 @@ function createRawTransaction(dataToSignHash, indices) {
 function startClient() {
   const config = getConfig();
 
-  const apiSecret = config.fireblocksApiSecret;
+  let apiSecret = config.fireblocksApiSecret;
   if (config.fireblocksApiSecretFile && fs.existsSync(config.fireblocksApiSecretFile)) {
     apiSecret = fs.readFileSync(config.fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
   }

--- a/src/services/fireblocks.service.js
+++ b/src/services/fireblocks.service.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const fs = require('fs');
 const crypto = require('crypto');
 const hathorLib = require('@hathor/wallet-lib');
 
@@ -345,10 +346,15 @@ function createRawTransaction(dataToSignHash, indices) {
 function startClient() {
   const config = getConfig();
 
+  const apiSecret = config.fireblocksApiSecret;
+  if (config.fireblocksApiSecretFile && fs.existsSync(config.fireblocksApiSecretFile)) {
+    apiSecret = fs.readFileSync(config.fireblocksApiSecretFile, { encoding: 'utf8' }).trim();
+  }
+
   return new FireblocksClient(
     config.fireblocksUrl,
     config.fireblocksApiKey,
-    config.fireblocksApiSecret,
+    apiSecret,
   );
 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -54,6 +54,10 @@ const { initHathorLib } = require('./helpers/wallet.helper');
  * HSM integration will be disabled
  * @property {string|null} [hsmUsername] - The HSM username to use.
  * @property {string|null} [hsmPassword] - The HSM password to use.
+ * @property {string|null} [fireblocksUrl] - The fireblocks url to use.
+ * @property {string|null} [fireblocksApiKey] - The fireblocks api key to use.
+ * @property {string|null} [fireblocksApiSecret] - The fireblocks api secret to use.
+ * @property {string|null} [fireblocksApiSecretFile] - The filepath of the fireblocks api secret.
  * @property {Record<string, MultiSigConfig>} [multisig] - The multisig config object
  * @property {string} [tokenUid] - The default token.
  * @property {number|null} [gapLimit] - a custom gap limit, if not present we
@@ -152,6 +156,7 @@ async function _analizeConfig(oldConfig, newConfig) {
 
   // Checking changes in the fields:
   // http_post, http_bind_address, http_api_key, consoleLevel, httpLogFormat, enabled_plugins
+  // fireblocksUrl, fireblocksApiKey, fireblocksApiSecret, fireblocksApiSecretFile
   //
   // We also do not support changing the HSM Credentials because a connection may be open at
   // the moment of the config change, and that would require a more complex logic to handle.
@@ -166,6 +171,10 @@ async function _analizeConfig(oldConfig, newConfig) {
     || oldConfig.hsmHost !== newConfig.hsmHost
     || oldConfig.hsmUsername !== newConfig.hsmUsername
     || oldConfig.hsmPassword !== newConfig.hsmPassword
+    || oldConfig.fireblocksUrl !== newConfig.fireblocksUrl
+    || oldConfig.fireblocksApiKey !== newConfig.fireblocksApiKey
+    || oldConfig.fireblocksApiSecret !== newConfig.fireblocksApiSecret
+    || oldConfig.fireblocksApiSecretFile !== newConfig.fireblocksApiSecretFile
   ) {
     action.nonRecoverable = true;
     return action;


### PR DESCRIPTION
### Description

The fireblocks secret is a PEM encoded private key, which means it is a multiline file.
Since our config is an object I encoded the file contents in a single line with `\n` separators where the line breaks should be.
This approach works for the config file (i.e. running locally on the repo), but it did not work consistently in docker.

Docker would escape the `\n` in the string making them `\\n` and the content unusable.
There is a way to use multiline environment variable but it only works on older versions of docker.

To solve this I decided to actually use a file when running on docker and the config would be the file path.
Since the file needs to be in the container it can be mounted as a volume, which works when running with docker, docker-compose and Kubernetes.

The example command would be:

```bash
docker run --rm \
  -p 8000:8000 \
  -v ${PWD}/fireblocks.secret:/sec/fireblocks.secret \
  -e HEADLESS_SEED_DEFAULT='default'
  -e HEADLESS_FIREBLOCKS_API_KEY='123' \
  -e HEADLESS_FIREBLOCKS_API_SECRET_FILE='/sec/fireblocks.secret' \  # <--- This is the config being affected
  -e HEADLESS_NETWORK=testnet \
  -e HEADLESS_SERVER=https://node1.testnet.hathor.network/v1a/ \
  hathornetwork/hathor-wallet-headless
```

### Acceptance Criteria

- When running on docker make `fireblocks_api_secret` config be a filepath which will read the file contents into the actual config.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
