### PR TITLE
fix: add tx timestamp and weight in the tx proposal API because it's needed for the tx mining service

### DIFF
--- a/__tests__/integration/readonly-wallet.test.js
+++ b/__tests__/integration/readonly-wallet.test.js
@@ -1,4 +1,4 @@
-import { helpersUtils, Network, walletUtils, transactionUtils } from '@hathor/wallet-lib';
+import { walletUtils, transactionUtils } from '@hathor/wallet-lib';
 import { precalculationHelpers, singleMultisigWalletData } from '../../scripts/helpers/wallet-precalculation.helper';
 import { TestUtils } from './utils/test-utils-integration';
 import { loggers } from './utils/logger.util';
@@ -160,7 +160,7 @@ describe('Readonly wallet', () => {
 
       // Generate input data
       const inputDatas = [];
-      for (let i=0; i < inputs.length; i++) {
+      for (let i = 0; i < inputs.length; i++) {
         response = await TestUtils.request
           .post('/wallet/tx-proposal/input-data')
           .send({

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -315,6 +315,10 @@ async function pushTxHex(req, res) {
   try {
     const network = new Network(config.network);
     const tx = helpersUtils.createTxFromHex(txHex, network);
+    if (!tx.weight) {
+      // We need to prepare this tx adding weight and timestamp
+      tx.prepareToSend();
+    }
     const sendTransaction = new SendTransaction({ transaction: tx });
     const response = await sendTransaction.runFromMining();
     res.send({ success: true, tx: mapTxReturn(response) });

--- a/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
+++ b/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
@@ -50,8 +50,10 @@ async function buildTxProposal(req, res) {
       pin: DEFAULT_PIN,
     });
     const fullTxData = await sendTransaction.prepareTxData();
-    // Do not sign or complete the transaction yet
+    // Do not sign the transaction yet
     const tx = transactionUtils.createTransactionFromData(fullTxData, network);
+    // Add weight and timestamp because it's needed for the tx mining service
+    tx.prepareToSend();
 
     res.send({ success: true, txHex: tx.toHex(), dataToSignHash: tx.getDataToSignHash().toString('hex') });
   } catch (err) {

--- a/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
+++ b/src/controllers/wallet/tx-proposal/tx-proposal.controller.js
@@ -50,10 +50,8 @@ async function buildTxProposal(req, res) {
       pin: DEFAULT_PIN,
     });
     const fullTxData = await sendTransaction.prepareTxData();
-    // Do not sign the transaction yet
+    // Do not sign or complete the transaction yet
     const tx = transactionUtils.createTransactionFromData(fullTxData, network);
-    // Add weight and timestamp because it's needed for the tx mining service
-    tx.prepareToSend();
 
     res.send({ success: true, txHex: tx.toHex(), dataToSignHash: tx.getDataToSignHash().toString('hex') });
   } catch (err) {


### PR DESCRIPTION
### Motivation

The [read only wallets tutorial](https://docs.hathor.network/tutorials/headless-wallet/read-only-wallets/) is not working in the latest headless wallet version. The reason for that is because we are creating a tx proposal without weight/timestamp, which is needed by the transaction mining service.

The tutorial was written using version 0.19.2, which used [wallet lib v0.42.1](https://github.com/HathorNetwork/hathor-wallet-headless/blob/v0.19.2/package.json#L15).

The tx proposal used to call [`prepareDate` method](https://github.com/HathorNetwork/hathor-wallet-headless/blob/v0.19.2/src/controllers/wallet/tx-proposal/tx-proposal.controller.js#L53), which called [completeTx method](https://github.com/HathorNetwork/hathor-wallet-lib/blob/v0.42.1/src/transaction.js#L717) that filled the weight and timestamp (https://github.com/HathorNetwork/hathor-wallet-lib/blob/v0.42.1/src/transaction.js#L523).

I could do this (and maybe it would be better) in the lib, inside the `prepareTxData` of the `SendTransaction` class but we want to release this fix as soon as possible because there is a use case waiting for it.

**Note:** I already created an [issue](https://github.com/HathorNetwork/hathor-wallet-headless/issues/441) to be discussed so we can add all scripts of tutorials we create in the Hathor docs to the headless CI, so we know when we break any tutorial and we can fix the code or update the tutorial.

### Acceptance Criteria
- Fill weight and timestamp in the tx proposal API.
- Improve read only wallet integration tests to guarantee the full flow is working fine.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
