### PR TITLE
docs(security): update link to bug bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security
 
-Hathor Labs has a bounty program to encourage white hat hackers to collaborate in identifying security breaches and vulnerabilities in Hathor headless wallet. To know more about this, see [https://immunefi.com/bounty/hathornetwork/](https://immunefi.com/bounty/hathornetwork/).
+Hathor Labs has a bounty program to encourage white hat hackers to collaborate in identifying security breaches and vulnerabilities in Hathor headless wallet. To know more about this, see [Bug bounty program at Hathor Network](https://hathor.network/bug-bounty/).


### PR DESCRIPTION
### Motivation

Update the "security" document link to point to the new security page on the main Hathor Network website.

### Acceptance Criteria

Updated link from:
https://docs.hathor.network/references/besides-documentation#security
To:
https://hathor.network/bug-bounty/
