### PR TITLE
chore: Upgrades CI workflow actions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,12 +27,13 @@ jobs:
         node-version: [20.x]
 
     steps:
-      # https://github.com/actions/checkout/releases/tag/v2.7.0
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
+      - name: Checkout
+        # https://github.com/actions/checkout/releases/tag/v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
       - name: Use Node.js ${{ matrix.node-version }}
-        # https://github.com/actions/setup-node/releases/tag/v1.4.6
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
+        # https://github.com/actions/setup-node/releases/tag/v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -43,8 +44,10 @@ jobs:
         run: npm run test_integration
 
       - name: Upload coverage
-        # https://github.com/codecov/codecov-action/releases/tag/v4.3.0
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed
+        # https://github.com/codecov/codecov-action/releases/tag/v4.5.0
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+        with:
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,13 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-      # https://github.com/actions/checkout/releases/tag/v2.7.0
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
+      - name: Checkout
+        # https://github.com/actions/checkout/releases/tag/v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
       - name: Use Node.js ${{ matrix.node-version }}
-        # https://github.com/actions/setup-node/releases/tag/v1.4.6
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e
+        # https://github.com/actions/setup-node/releases/tag/v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -38,7 +40,9 @@ jobs:
         run: npm run test
 
       - name: Upload coverage
-        # https://github.com/codecov/codecov-action/releases/tag/v4.3.0
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed
+        # https://github.com/codecov/codecov-action/releases/tag/v4.5.0
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+        with:
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Acceptance Criteria
- Fixes warnings about the CI workflow actions to use NodeJS 20
- Forces an error on CI if CodeCov fails, to improve our understanding of its errors

### Notes
The `upload-artifact` and `gh-docker-logs` actions will be upgraded in a future moment, as they have breaking changes that will need more attention to adapt to.

The intermittent errors we're having of not finding the secret token on CodeCov seems to have been fixed by the latest action version. Recent issues about this problem were found on [1463](https://github.com/codecov/codecov-action/issues/1463) and [1425](https://github.com/codecov/codecov-action/issues/1425) with no definitive solution.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
