### PR TITLE
fix: multisig config on Docker

### DIFF
--- a/config.js.docker
+++ b/config.js.docker
@@ -103,8 +103,8 @@ for (const x of seeds) {
   // Multisig configuration and validation
   const multisigPubkeys = getParam(`multisig_seed_${x}_pubkeys`);
   const multisig = {
-    total:          getParam(`multisig_seed_${x}_max_signatures`),
-    numSignatures:  getParam(`multisig_seed_${x}_num_signatures`),
+    total:          getIntParam(`multisig_seed_${x}_max_signatures`),
+    numSignatures:  getIntParam(`multisig_seed_${x}_num_signatures`),
   };
   if (!(multisigPubkeys || multisig.total || multisig.numSignatures)) {
     // No multisig parameters means this is not a multisig.


### PR DESCRIPTION
### Acceptance Criteria
This PR extracts a fix from https://github.com/HathorNetwork/hathor-wallet-headless/pull/450, so I just copied the description from there, which was good enough:

- Fixing multisig param types: when deploying on some cloud environments (such as GCP Cloud Run), the **_multisig_seed_${x}_max_signatures_** and **_multisig_seed_${x}_num_signatures_** are threated as strings, not integers. When starting the multisig, the comparison made with this params is a exact on (  "===") so it fails. By parsing the params before we can avoid that.

src/controllers/index.controller.js Ln 100-101:

```
  const mconfig = config.multisig[multisigKey];
    console.log('mconfig', mconfig);
    if (!(mconfig
           && (mconfig.total && mconfig.numSignatures && mconfig.pubkeys)
           && (mconfig.pubkeys.length === mconfig.total)
           && (mconfig.numSignatures <= mconfig.total))) {
      // Missing multisig items
      console.error(`Improperly configured multisig for seed ${multisigKey}.`);
      res.send({
        success: false,
        message: `Improperly configured multisig for seed ${multisigKey}.`
      });
      return;
```



### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
