### PR TITLE
feat: use wallet facade method to mark inputs as selected

### DIFF
--- a/__tests__/__fixtures__/ws-fixtures.js
+++ b/__tests__/__fixtures__/ws-fixtures.js
@@ -1,4 +1,5 @@
 export default {
+  capabilities: { capabilities: ['history-streaming'] },
   dashboard: {
     transactions: 2,
     blocks: 1537,

--- a/__tests__/history-sync.test.js
+++ b/__tests__/history-sync.test.js
@@ -6,6 +6,10 @@ import { initializedWallets } from '../src/services/wallets.service';
 const walletId = 'stub_history_sync';
 
 describe('history sync', () => {
+  beforeEach(() => {
+    settings._resetConfig();
+  });
+
   afterEach(async () => {
     await TestUtils.stopWallet({ walletId });
   });
@@ -27,11 +31,11 @@ describe('history sync', () => {
     const response = await TestUtils.request
       .post('/start')
       .send({ seedKey: TestUtils.seedKey, 'wallet-id': walletId });
-    settings._resetConfig();
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     const wallet = initializedWallets.get(walletId);
     expect(wallet.historySyncMode).toEqual(hathorLib.HistorySyncMode.MANUAL_STREAM_WS);
+    await TestUtils.stopWallet({ walletId });
   });
 
   it('should use the history sync from the request when provided', async () => {
@@ -45,7 +49,6 @@ describe('history sync', () => {
         'wallet-id': walletId,
         history_sync_mode: 'xpub_stream_ws',
       });
-    settings._resetConfig();
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     const wallet = initializedWallets.get(walletId);

--- a/__tests__/mark_utxos_selected_as_input.test.js
+++ b/__tests__/mark_utxos_selected_as_input.test.js
@@ -109,7 +109,7 @@ describe('mark utxos selected_as_input api', () => {
     expect(selectSpy).toHaveBeenCalledWith(
       { index: 0, txId: '5db0a8c77f818c51cb107532fc1a36785adfa700d81d973fd1f23438b2f3dd74' },
       true,
-      undefined,
+      null,
     );
   });
 
@@ -141,7 +141,7 @@ describe('mark utxos selected_as_input api', () => {
     expect(selectSpy).toHaveBeenCalledWith(
       { index: 0, txId: '5db0a8c77f818c51cb107532fc1a36785adfa700d81d973fd1f23438b2f3dd74' },
       false,
-      undefined,
+      null,
     );
   });
 
@@ -157,7 +157,7 @@ describe('mark utxos selected_as_input api', () => {
     expect(selectSpy).toHaveBeenCalledWith(
       { index: 0, txId: '5db0a8c77f818c51cb107532fc1a36785adfa700d81d973fd1f23438b2f3dd74' },
       true,
-      undefined,
+      null,
     );
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dinamonetworks/hsm-dinamo": "4.9.1",
         "@hathor/healthcheck-lib": "0.1.0",
-        "@hathor/wallet-lib": "1.12.1",
+        "@hathor/wallet-lib": "1.13.0",
         "axios": "1.7.2",
         "express": "4.18.2",
         "express-validator": "6.10.0",
@@ -2168,9 +2168,9 @@
       "integrity": "sha512-Oi223+iKye5cmPyMIqp64E/ZP+in0JndN/s9uEigmXxt6wRhwciCPbzSY4S2oicy1uNqhv7lLdyUc3O/P3sCzQ=="
     },
     "node_modules/@hathor/wallet-lib": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.12.1.tgz",
-      "integrity": "sha512-kunwYdIJwc0EEQ7LUjOwsu0/s7nrecxVlUgGi6T0ssuvkMVX3NPjHextb+TDzMMQWgEMTX+6qVcXntbEuZ1Y7g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.13.0.tgz",
+      "integrity": "sha512-nOAmsKC5yeYxMHBTKS6PEUBOEVxNVQzK6yNTFG4Jhiol4YK+TcSJalECkezo4NKzfdr9DiUiNDseuAfbdEQ78g==",
       "license": "MIT",
       "dependencies": {
         "abstract-level": "1.0.4",
@@ -2183,7 +2183,7 @@
         "level": "8.0.1",
         "lodash": "4.17.21",
         "long": "5.2.3",
-        "queue-promise": "^2.2.1",
+        "queue-microtask": "1.2.3",
         "ws": "8.17.1"
       },
       "engines": {
@@ -9976,15 +9976,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/queue-promise": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/queue-promise/-/queue-promise-2.2.1.tgz",
-      "integrity": "sha512-C3eyRwLF9m6dPV4MtqMVFX+Xmc7keZ9Ievm3jJ/wWM5t3uVbFnGsJXwpYzZ4LaIEcX9bss/mdaKzyrO6xheRuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.12.0"
-      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@dinamonetworks/hsm-dinamo": "4.9.1",
     "@hathor/healthcheck-lib": "0.1.0",
-    "@hathor/wallet-lib": "1.12.1",
+    "@hathor/wallet-lib": "1.13.0",
     "axios": "1.7.2",
     "express": "4.18.2",
     "express-validator": "6.10.0",

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -13,7 +13,6 @@ const settings = require('../src/settings');
   // Fetch config data from this instance and generate the ApiDocs
   await settings.setupConfig();
   const docsObj = getApiDocs();
-  console.log(JSON.stringify(docsObj));
 
   // Output to temporary JSON file
   await writeFile('./tmp/api-docs.json', JSON.stringify(docsObj, null, 2));
@@ -22,6 +21,6 @@ const settings = require('../src/settings');
     process.exit(0);
   })
   .catch(err => {
-    console.error(err.stack)
+    console.error(err.stack);
     process.exit(1);
   });

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -13,8 +13,15 @@ const settings = require('../src/settings');
   // Fetch config data from this instance and generate the ApiDocs
   await settings.setupConfig();
   const docsObj = getApiDocs();
+  console.log(JSON.stringify(docsObj));
 
   // Output to temporary JSON file
   await writeFile('./tmp/api-docs.json', JSON.stringify(docsObj, null, 2));
 })()
-  .catch(err => console.error(err.stack));
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error(err.stack)
+    process.exit(1);
+  });

--- a/src/helpers/tx.helper.js
+++ b/src/helpers/tx.helper.js
@@ -6,6 +6,7 @@
  */
 
 const { constants: { NATIVE_TOKEN_UID } } = require('@hathor/wallet-lib');
+/** @import { HathorWallet } from '@hathor/wallet-lib' */
 
 /**
  * The endpoints that return a created tx must keep compatibility
@@ -239,7 +240,7 @@ async function getTx(wallet, id, options) {
 
 /**
  * Mark or unmark all utxos as selected_as_input on the given storage.
- * @param {import('@hathor/wallet-lib').HathorWallet} wallet
+ * @param {HathorWallet} wallet
  * @param {{ txId: string, index: number }[]} utxos
  * @param {boolean} [markAs=true]
  * @param {number?} [ttl=undefined]
@@ -247,7 +248,7 @@ async function getTx(wallet, id, options) {
 async function markUtxosSelectedAsInput(wallet, utxos, markAs, ttl) {
   const mark = markAs ?? true;
   for (const utxo of utxos) {
-    await wallet.storage.utxoSelectAsInput(utxo, mark, ttl);
+    await wallet.markUtxoSelected(utxo.txId, utxo.index, mark, ttl);
   }
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Bump wallet-lib to latest version
- Use wallet facade method to mark utxos as selected_as_input instead of storage method.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
