### PR TITLE
feat: add missing parameters in nano contract API

### DIFF
--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -3750,6 +3750,24 @@ const defaultApiDocs = {
               },
             }
           },
+          {
+            name: 'block_hash',
+            in: 'query',
+            description: 'Hash of the block to get the state.',
+            required: false,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'block_height',
+            in: 'query',
+            description: 'Height of the block to get the state.',
+            required: false,
+            schema: {
+              type: 'integer',
+            },
+          },
         ],
         responses: {
           200: {
@@ -3823,6 +3841,15 @@ const defaultApiDocs = {
             name: 'after',
             in: 'query',
             description: 'Hash of transaction to offset the result.',
+            required: false,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'before',
+            in: 'query',
+            description: 'Hash of transaction to offset the result for previous transactions.',
             required: false,
             schema: {
               type: 'string',

--- a/src/controllers/wallet/nano-contracts.controller.js
+++ b/src/controllers/wallet/nano-contracts.controller.js
@@ -21,10 +21,24 @@ async function getState(req, res) {
     return;
   }
 
-  const { id, fields, balances, calls } = req.query;
+  const {
+    id,
+    fields,
+    balances,
+    calls,
+    block_hash: blockHash,
+    block_height: blockHeight
+  } = req.query;
 
   try {
-    const state = await ncApi.getNanoContractState(id, fields, balances, calls);
+    const state = await ncApi.getNanoContractState(
+      id,
+      fields,
+      balances,
+      calls,
+      blockHash,
+      blockHeight
+    );
 
     res.send({
       success: true,
@@ -45,10 +59,10 @@ async function getHistory(req, res) {
     return;
   }
 
-  const { id, count, after } = req.query;
+  const { id, count, after, before } = req.query;
 
   try {
-    const data = await ncApi.getNanoContractHistory(id, count, after);
+    const data = await ncApi.getNanoContractHistory(id, count, after, before);
 
     res.send({
       success: true,

--- a/src/routes/wallet/nano-contracts.routes.js
+++ b/src/routes/wallet/nano-contracts.routes.js
@@ -30,6 +30,8 @@ nanoContractRouter.get(
   query('fields').isArray().optional().default([]),
   query('balances').isArray().optional().default([]),
   query('calls').isArray().optional().default([]),
+  query('block_hash').isString().optional(),
+  query('block_height').isInt({ min: 0 }).optional().toInt(),
   getState
 );
 
@@ -68,6 +70,7 @@ nanoContractRouter.get(
   query('id').isString(),
   query('count').isInt({ min: 0 }).optional().toInt(),
   query('after').isString().optional(),
+  query('before').isString().optional(),
   getHistory
 );
 


### PR DESCRIPTION
### Acceptance Criteria
- Add `before` query parameter to the nano contract history API.
- Add `block_hash` and `block_height` query parameters to the nano contract state API.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
