### PR TITLE
hsm share lock

### DIFF
--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -16,7 +16,7 @@ const {
 } = require('@hathor/wallet-lib');
 const atomicSwapService = require('../../../services/atomic-swap.service');
 const { parametersValidation } = require('../../../helpers/validations.helper');
-const { lock, lockTypes } = require('../../../lock');
+const { lockTypes } = require('../../../lock');
 const { mapTxReturn, runSendTransaction } = require('../../../helpers/tx.helper');
 const constants = require('../../../constants');
 const { removeListenedProposal } = require('../../../services/atomic-swap.service');

--- a/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
+++ b/src/controllers/wallet/atomic-swap/tx-proposal.controller.js
@@ -20,7 +20,7 @@ const { lock, lockTypes } = require('../../../lock');
 const { mapTxReturn, runSendTransaction } = require('../../../helpers/tx.helper');
 const constants = require('../../../constants');
 const { removeListenedProposal } = require('../../../services/atomic-swap.service');
-const { lockSendTx } = require('../../../helpers/lock.helper');
+const { lockSendTx, getWalletLock } = require('../../../helpers/lock.helper');
 const { cantSendTxErrorMessage } = require('../../../helpers/constants');
 
 /**
@@ -407,7 +407,7 @@ async function unlockInputs(req, res) {
     return;
   }
 
-  const canStart = lock.get(req.walletId).lock(lockTypes.SEND_TX);
+  const canStart = getWalletLock(req.walletId).lock(lockTypes.SEND_TX);
   if (!canStart) {
     res.send({ success: false, error: 'Cannot run this method while a transaction is being sent.' });
     return;
@@ -427,7 +427,7 @@ async function unlockInputs(req, res) {
   } catch (err) {
     res.send({ success: false, error: err.message });
   } finally {
-    lock.get(req.walletId).unlock(lockTypes.SEND_TX);
+    getWalletLock(req.walletId).unlock(lockTypes.SEND_TX);
   }
 }
 

--- a/src/helpers/lock.helper.js
+++ b/src/helpers/lock.helper.js
@@ -6,6 +6,7 @@
  */
 
 const { lock, lockTypes } = require('../lock');
+const { hsmWalletIds } = require('../services/wallets.service');
 
 /**
  * Acquire the SEND_TX lock for a wallet and return the method to unlock it.
@@ -15,7 +16,14 @@ const { lock, lockTypes } = require('../lock');
  *
  */
 function lockSendTx(walletId) {
-  const walletLock = lock.get(walletId);
+  let walletLock;
+  if (hsmWalletIds.has(walletId)) {
+    // This is an HSM wallet and the walletLock should be global.
+    walletLock = lock.hsmLock;
+  } else {
+    walletLock = lock.get(walletId);
+  }
+
   const canStart = walletLock.lock(lockTypes.SEND_TX);
   if (!canStart) {
     return null;

--- a/src/helpers/lock.helper.js
+++ b/src/helpers/lock.helper.js
@@ -16,9 +16,8 @@ function getWalletLock(walletId) {
   if (hsmWalletIds.has(walletId)) {
     // This is an HSM wallet and the walletLock should be global.
     return lock.hsmLock;
-  } else {
-    return lock.get(walletId);
   }
+  return lock.get(walletId);
 }
 
 /**

--- a/src/helpers/lock.helper.js
+++ b/src/helpers/lock.helper.js
@@ -9,6 +9,19 @@ const { lock, lockTypes } = require('../lock');
 const { hsmWalletIds } = require('../services/wallets.service');
 
 /**
+ * Get the Lock instance for the given walletID.
+ * @param {string} walletId
+ */
+function getWalletLock(walletId) {
+  if (hsmWalletIds.has(walletId)) {
+    // This is an HSM wallet and the walletLock should be global.
+    return lock.hsmLock;
+  } else {
+    return lock.get(walletId);
+  }
+}
+
+/**
  * Acquire the SEND_TX lock for a wallet and return the method to unlock it.
  *
  * @param {string} walletId
@@ -16,13 +29,7 @@ const { hsmWalletIds } = require('../services/wallets.service');
  *
  */
 function lockSendTx(walletId) {
-  let walletLock;
-  if (hsmWalletIds.has(walletId)) {
-    // This is an HSM wallet and the walletLock should be global.
-    walletLock = lock.hsmLock;
-  } else {
-    walletLock = lock.get(walletId);
-  }
+  const walletLock = getWalletLock(walletId);
 
   const canStart = walletLock.lock(lockTypes.SEND_TX);
   if (!canStart) {
@@ -42,4 +49,5 @@ function lockSendTx(walletId) {
 
 module.exports = {
   lockSendTx,
+  getWalletLock,
 };

--- a/src/lock.js
+++ b/src/lock.js
@@ -78,6 +78,9 @@ class GlobalLock {
     // This is the global lock since some methods are required to be
     // running only once across all wallets.
     this.globalLock = new Lock();
+    // HSM wallets need to share the same send-tx lock because the SDK does not
+    // allow 2 open connections at the same time.
+    this._hsmLock = new Lock();
   }
 
   delete(walletId) {
@@ -102,6 +105,10 @@ class GlobalLock {
 
   unlock(type) {
     this.globalLock.unlock(type);
+  }
+
+  get hsmLock() {
+    return this._hsmLock;
   }
 }
 


### PR DESCRIPTION
### Acceptance Criteria

- All HSM wallets should share the same lock

This is due to a limit on the HSM SDK that trying to start a second connection would fail.
So the wallets should only have 1 connection open at any given time, which is done with the lock system.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
