### PR TITLE
feat: script to get multisig xpub from seed easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,15 @@ else
 	node dist-scripts/get_xpub_from_seed.js $(seed)
 endif
 
+# Internal target to run multisig_xpub_from_seed command.
+.PHONY: .run_multisig_xpub_from_seed
+.run_multisig_xpub_from_seed:
+ifeq ($(seed),)
+	@echo "Usage: make multisig_xpub_from_seed seed=YOUR_SEED"
+else
+	node dist-scripts/get_multisig_xpub_from_seed.js $(seed)
+endif
+
 # Command: generate words
 .PHONY: words
 words: .script-build-dirs .run_words .script-clean-dirs
@@ -76,3 +85,7 @@ create_hsm_key: .script-build-dirs .run_create_hsm_key .script-clean-dirs
 # Command: Derive xPub from seed
 .PHONY: xpub_from_seed
 xpub_from_seed: .script-build-dirs .run_xpub_from_seed .script-clean-dirs
+
+# Command: Derive multisig xPub from seed
+.PHONY: multisig_xpub_from_seed
+multisig_xpub_from_seed: .script-build-dirs .run_multisig_xpub_from_seed .script-clean-dirs

--- a/docs/multisig-wallets.md
+++ b/docs/multisig-wallets.md
@@ -44,21 +44,33 @@ The order of the pubkeys is not important.
 
 ## Collect pubkeys
 
-Configure your wallet normally and use the `/multisig-pubkey` to get your pubkey.
+There are two ways for getting the pubkey.
+
+1. Configure your wallet normally and use the `/multisig-pubkey` to get your pubkey.
+2. Use the `make multisig_xpub_from_seed` command to generate the pubkey.
+
 This public key will be shared among all participants and will be used in the configuration file in the pubkeys array.
-You don't need to start the wallet yet.
 
 ### POST /multisig-pubkey
+
+You don't need to start the wallet before sending this request, just have the seedKey configured in your configuration file.
 
 Parameters:
 
 `seedKey`: Parameter to define which seed (from the object seeds in the config file) will be used to generate the pubkey.
 `passphrase`: Optional parameter to generate the pubkey with a passphrase. If not sent we use empty string. Should be the same when starting the wallet later.
 
-
 ```bash
 $ curl -X POST --data-urlencode "passphrase=123" --data "seedKey=default" http://localhost:8000/multisig-pubkey
 {"success":true,"xpubkey":"xpub..."}
+```
+
+### make multisig_xpub_from_seed
+
+Just run the command, passing the seed key as argument. This method does not support passphrase yet, use the previous method if you need it.
+
+```bash
+make multisig_xpub_from_seed seed='<seed words>'
 ```
 
 ## Start a MultiSig Wallet

--- a/scripts/get_multisig_xpub_from_seed.js
+++ b/scripts/get_multisig_xpub_from_seed.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import hathorLib from '@hathor/wallet-lib';
+
+function main() {
+  /**
+  * argv contains the cli arguments that made this script run, including the interpreter
+  * and script filename so to get the actual seed passed via cli we need to remove the
+  * other arguments.
+  * argv = ["babel-node", "get_xpub_from_seed.js", "word0", ..., "wordLast"];
+  * We need to remove the first 2 and join the other arguments into a single string
+  * separated by spaces
+  */
+  const seed = process.argv.slice(2).join(' ');
+  const xpubkey = hathorLib.walletUtils.getMultiSigXPubFromWords(seed);
+
+  // Print the xpubkey
+  console.log(xpubkey);
+}
+
+try {
+  main();
+  process.exit(0);
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
### Acceptance Criteria
- We should be able to run `make multisig_xpub_from_seed seed="<seed words>"` to get a multisig xpub from seed

### Motivation

- Some people were mistakenly using `make xpub_from_seed` for this.
- It will make it easier to generate a multisig xpub in automated environments


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
