### PR TITLE
fix: support for BigInt on plugins

### DIFF
--- a/__tests__/plugins/child.test.js
+++ b/__tests__/plugins/child.test.js
@@ -1,0 +1,40 @@
+import { bigIntUtils } from '@hathor/wallet-lib';
+import { handleMessage } from '../../src/plugins/child';
+import { notificationBus, EVENTBUS_EVENT_NAME } from '../../src/services/notification.service';
+
+jest.mock('../../src/services/notification.service', () => ({
+  notificationBus: {
+    emit: jest.fn(),
+  },
+  EVENTBUS_EVENT_NAME: 'eventbus_event',
+}));
+
+describe('handleMessage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should parse the serialized data and emit the eventbus event', () => {
+    const mockData = { type: 'custom_event', payload: 'test', bigint: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
+
+    handleMessage(bigIntUtils.JSONBigInt.stringify(mockData));
+
+    expect(notificationBus.emit).toHaveBeenCalledWith(EVENTBUS_EVENT_NAME, mockData);
+  });
+
+  it('should emit the specific event type if present in the data', () => {
+    const mockData = { type: 'custom_event', payload: 'test', bigint: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
+
+    handleMessage(bigIntUtils.JSONBigInt.stringify(mockData));
+
+    expect(notificationBus.emit).toHaveBeenCalledWith(mockData.type, mockData);
+  });
+
+  it('should not emit a specific event type if type is not present in the data', () => {
+    const mockData = { payload: 'test', bigint: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
+
+    handleMessage(bigIntUtils.JSONBigInt.stringify(mockData));
+
+    expect(notificationBus.emit).not.toHaveBeenCalledWith(mockData.type, mockData);
+  });
+});

--- a/__tests__/plugins/debug_plugin.test.js
+++ b/__tests__/plugins/debug_plugin.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { eventHandler, getSettings } from '../../src/plugins/hathor_debug';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { eventHandler, getSettings } from '../../src/plugins/hathor_debug';
 
 test('settings', () => {
   const oldArgs = process.argv;
@@ -68,7 +68,9 @@ test('event handler', () => {
   logSpy.mockReset();
   // big message: should log the entire message
   eventHandler(bigCompleteMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(bigCompleteMsg)));
+  expect(logSpy).toHaveBeenCalledWith(
+    toDebugMessage(bigIntUtils.JSONBigInt.stringify(bigCompleteMsg))
+  );
 
   // debugLong: unexpected value
   process.argv = [

--- a/__tests__/plugins/debug_plugin.test.js
+++ b/__tests__/plugins/debug_plugin.test.js
@@ -6,6 +6,7 @@
  */
 
 import { eventHandler, getSettings } from '../../src/plugins/hathor_debug';
+import { bigIntUtils } from '@hathor/wallet-lib';
 
 test('settings', () => {
   const oldArgs = process.argv;
@@ -27,9 +28,9 @@ test('settings', () => {
 test('event handler', () => {
   const oldArgs = process.argv;
   const logSpy = jest.spyOn(console, 'log');
-  const smallMsg = { type: 'small', walletId: 'default', foo: 'bar' };
+  const smallMsg = { type: 'small', walletId: 'default', foo: 'bar', bigInt: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
   const bigMsg = { type: 'big', walletId: 'default' };
-  const bigCompleteMsg = { ...bigMsg, message: '' };
+  const bigCompleteMsg = { ...bigMsg, message: '', bigInt: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
   for (let i = 0; i < 200; i++) {
     // 200 * 'aaaaa'(length of 5) -> lenght of 1000
     bigCompleteMsg.message += 'aaaaa';
@@ -48,7 +49,7 @@ test('event handler', () => {
   logSpy.mockReset();
   // small message: always log
   eventHandler(smallMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(smallMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(smallMsg)));
   logSpy.mockReset();
   // big message: should not log
   eventHandler(bigCompleteMsg);
@@ -63,11 +64,11 @@ test('event handler', () => {
   logSpy.mockReset();
   // small message: always log
   eventHandler(smallMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(smallMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(smallMsg)));
   logSpy.mockReset();
   // big message: should log the entire message
   eventHandler(bigCompleteMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(bigCompleteMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(bigCompleteMsg)));
 
   // debugLong: unexpected value
   process.argv = [
@@ -78,11 +79,11 @@ test('event handler', () => {
   logSpy.mockReset();
   // small message: always log
   eventHandler(smallMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(smallMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(smallMsg)));
   logSpy.mockReset();
   // big message: should log partially
   eventHandler(bigCompleteMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(bigMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(bigMsg)));
 
   // debugLong: default (should be the same as unexpected)
   process.argv = [
@@ -92,11 +93,11 @@ test('event handler', () => {
   logSpy.mockReset();
   // small message: always log
   eventHandler(smallMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(smallMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(smallMsg)));
   logSpy.mockReset();
   // big message: should log partially
   eventHandler(bigCompleteMsg);
-  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(JSON.stringify(bigMsg)));
+  expect(logSpy).toHaveBeenCalledWith(toDebugMessage(bigIntUtils.JSONBigInt.stringify(bigMsg)));
 
   // Restore original argv state
   process.argv = oldArgs;

--- a/__tests__/plugins/rabbitmq_plugin.test.js
+++ b/__tests__/plugins/rabbitmq_plugin.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_rabbitmq';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_rabbitmq';
 
 test('settings', () => {
   const oldArgs = process.argv;

--- a/__tests__/plugins/rabbitmq_plugin.test.js
+++ b/__tests__/plugins/rabbitmq_plugin.test.js
@@ -6,6 +6,7 @@
  */
 
 import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_rabbitmq';
+import { bigIntUtils } from '@hathor/wallet-lib';
 
 test('settings', () => {
   const oldArgs = process.argv;
@@ -34,5 +35,5 @@ test('event handler', () => {
   const data = { test: 'event' };
 
   evHandler(data);
-  expect(channelMock.sendToQueue).toHaveBeenCalledWith('test-queue', Buffer.from(JSON.stringify(data)));
+  expect(channelMock.sendToQueue).toHaveBeenCalledWith('test-queue', Buffer.from(bigIntUtils.JSONBigInt.stringify(data)));
 });

--- a/__tests__/plugins/sqs_plugin.test.js
+++ b/__tests__/plugins/sqs_plugin.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_sqs';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_sqs';
 
 test('settings', () => {
   const oldArgs = process.argv;

--- a/__tests__/plugins/sqs_plugin.test.js
+++ b/__tests__/plugins/sqs_plugin.test.js
@@ -6,6 +6,7 @@
  */
 
 import { eventHandlerFactory, getSettings } from '../../src/plugins/hathor_sqs';
+import { bigIntUtils } from '@hathor/wallet-lib';
 
 test('settings', () => {
   const oldArgs = process.argv;
@@ -47,11 +48,11 @@ test('event handler', () => {
   };
   const mockedSettings = { queueUrl: 'test-queue' };
   const evHandler = eventHandlerFactory(sqsMock, mockedSettings);
-  const data = { test: 'event' };
+  const data = { test: 'event', bigInt: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
 
   evHandler(data);
   expect(sqsMock.sendMessage).toHaveBeenCalledWith({
     QueueUrl: mockedSettings.queueUrl,
-    MessageBody: JSON.stringify(data),
+    MessageBody: bigIntUtils.JSONBigInt.stringify(data),
   }, expect.anything());
 });

--- a/__tests__/plugins/ws_plugin.test.js
+++ b/__tests__/plugins/ws_plugin.test.js
@@ -6,6 +6,7 @@
  */
 
 import { getSockets, eventHandler, connectionHandler, getSettings } from '../../src/plugins/hathor_websocket';
+import { bigIntUtils } from '@hathor/wallet-lib';
 
 test('settings', () => {
   const oldArgs = process.argv;
@@ -55,9 +56,10 @@ test('event handler', () => {
   connectionHandler(socket1);
   connectionHandler(socket2);
 
-  eventHandler({ foo: 'bar' });
-  expect(socket1.send).toHaveBeenCalledWith('{"foo":"bar"}');
-  expect(socket2.send).toHaveBeenCalledWith('{"foo":"bar"}');
+  const data = { foo: 'bar', bigInt: BigInt(Number.MAX_SAFE_INTEGER) + 1n };
+  eventHandler(data);
+  expect(socket1.send).toHaveBeenCalledWith(bigIntUtils.JSONBigInt.stringify(data));
+  expect(socket2.send).toHaveBeenCalledWith(bigIntUtils.JSONBigInt.stringify(data));
 
   // simulate disconnections
   socket1.cb();

--- a/__tests__/plugins/ws_plugin.test.js
+++ b/__tests__/plugins/ws_plugin.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getSockets, eventHandler, connectionHandler, getSettings } from '../../src/plugins/hathor_websocket';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { getSockets, eventHandler, connectionHandler, getSettings } from '../../src/plugins/hathor_websocket';
 
 test('settings', () => {
   const oldArgs = process.argv;

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -134,3 +134,18 @@ The `custom_plugin.js` file will have the plugin logic.
 To configure custom plugins you need to add the plugin id to the [enabled plugins](#configuration) and for each custom plugin there should be 2 new variables, the `--plugin_<pluginId>_file` (or `HEADLESS_PLUGIN_<pluginId>_FILE`) and `--plugin_<pluginId>_name` (or `HEADLESS_PLUGIN_<pluginId>_NAME`).
 
 Any configuration of the plugin itself will be made outside the config module.
+
+### BigInt support
+
+We have support for BigInt on the headless, which means it's possible that data sent to the plugins will contain BigInt values.
+
+In case your plugin needs to serialize data to send it upstream to some other tool, you may want to use our serialization tools available at the `wallet-lib` in order to guarantee the correct serialization of BigInt data.
+
+They can be used like so:
+
+```javascript
+import { bigIntUtils } from 'wallet-lib';
+
+const serializedData = bigIntUtils.JSONBigInt.stringify(data);
+const deserializedData = bigIntUtils.JSONBigInt.parse(serializedData);
+```

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@
 
 /* istanbul ignore file */
 import { fork } from 'child_process';
-import { config as hathorLibConfig } from '@hathor/wallet-lib';
+import { config as hathorLibConfig, bigIntUtils } from '@hathor/wallet-lib';
 
 import createApp from './app';
 import { EVENTBUS_EVENT_NAME, notificationBus } from './services/notification.service';
@@ -71,7 +71,7 @@ async function startHeadless() {
         return;
       }
       // Sending event data
-      child.send(data);
+      child.send(bigIntUtils.JSONBigInt.stringify(data));
     });
   }
 

--- a/src/plugins/child.js
+++ b/src/plugins/child.js
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import settings from '../settings';
+import { bigIntUtils } from '@hathor/wallet-lib';
 
 import { notificationBus, EVENTBUS_EVENT_NAME } from '../services/notification.service';
 
@@ -121,7 +122,8 @@ if (process.env.NODE_ENV !== 'test') {
     process.exit(127);
   });
 
-  process.on('message', data => {
+  process.on('message', serializedData => {
+    const data = bigIntUtils.JSONBigInt.parse(serializedData);
     // Repeat notifications from main process to local notification service
     notificationBus.emit(EVENTBUS_EVENT_NAME, data);
     if (data.type) {

--- a/src/plugins/child.js
+++ b/src/plugins/child.js
@@ -6,8 +6,8 @@
  */
 
 import path from 'path';
-import settings from '../settings';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import settings from '../settings';
 
 import { notificationBus, EVENTBUS_EVENT_NAME } from '../services/notification.service';
 
@@ -115,6 +115,16 @@ export const main = async () => {
   }
 };
 
+// We export this just for testing purposes
+export const handleMessage = serializedData => {
+  const data = bigIntUtils.JSONBigInt.parse(serializedData);
+  // Repeat notifications from main process to local notification service
+  notificationBus.emit(EVENTBUS_EVENT_NAME, data);
+  if (data.type) {
+    notificationBus.emit(data.type, data);
+  }
+};
+
 if (process.env.NODE_ENV !== 'test') {
   process.on('disconnect', () => {
     // If parent disconnects, we must exit to avoid running indefinetly
@@ -122,14 +132,7 @@ if (process.env.NODE_ENV !== 'test') {
     process.exit(127);
   });
 
-  process.on('message', serializedData => {
-    const data = bigIntUtils.JSONBigInt.parse(serializedData);
-    // Repeat notifications from main process to local notification service
-    notificationBus.emit(EVENTBUS_EVENT_NAME, data);
-    if (data.type) {
-      notificationBus.emit(data.type, data);
-    }
-  });
+  process.on('message', handleMessage);
 
   console.log('[child_process] startup');
   main();

--- a/src/plugins/hathor_debug.js
+++ b/src/plugins/hathor_debug.js
@@ -4,6 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { bigIntUtils } from '@hathor/wallet-lib';
+
 let debugLong;
 
 /* istanbul ignore next */
@@ -38,7 +40,7 @@ function debugLog(data) {
 }
 
 export function eventHandler(data) {
-  const message = JSON.stringify(data);
+  const message = bigIntUtils.JSONBigInt.stringify(data);
   if (message.length < 1000) {
     debugLog(message);
     return;

--- a/src/plugins/hathor_rabbitmq.js
+++ b/src/plugins/hathor_rabbitmq.js
@@ -6,6 +6,9 @@
  */
 
 /* istanbul ignore next */
+
+import { bigIntUtils } from '@hathor/wallet-lib';
+
 async function checkDeps() {
   const requiredDeps = {
     yargs: '^17.7.2',
@@ -39,7 +42,7 @@ export function getSettings() {
 
 export function eventHandlerFactory(channel, settings) {
   return data => {
-    channel.sendToQueue(settings.queue, Buffer.from(JSON.stringify(data)));
+    channel.sendToQueue(settings.queue, Buffer.from(bigIntUtils.JSONBigInt.stringify(data)));
   };
 }
 

--- a/src/plugins/hathor_sqs.js
+++ b/src/plugins/hathor_sqs.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { bigIntUtils } from '@hathor/wallet-lib';
+
 /* istanbul ignore next */
 async function checkDeps() {
   const requiredDeps = {
@@ -53,7 +55,7 @@ export function eventHandlerFactory(sqs, settings) {
   return data => {
     const params = {
       QueueUrl: settings.queueUrl,
-      MessageBody: JSON.stringify(data),
+      MessageBody: bigIntUtils.JSONBigInt.stringify(data),
     };
     sqs.sendMessage(params, err => {
       if (err) {

--- a/src/plugins/hathor_websocket.js
+++ b/src/plugins/hathor_websocket.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { bigIntUtils } from '@hathor/wallet-lib';
+
 /* istanbul ignore next */
 async function checkDeps() {
   const requiredDeps = {
@@ -60,7 +62,7 @@ export function connectionHandler(socket) {
 export function eventHandler(data) {
   // Broadcast to all live connections
   for (const socket of sockets) {
-    socket.send(JSON.stringify(data));
+    socket.send(bigIntUtils.JSONBigInt.stringify(data));
   }
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Events containing BigInt fields should be correctly sent to the plugins process
- The plugins should all serialize data in a way that supports BigInt


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
