### PR TITLE
chore: update action runner to ubuntu-latest

### DIFF
--- a/.github/workflows/apidocs-upload.yml
+++ b/.github/workflows/apidocs-upload.yml
@@ -11,7 +11,7 @@ jobs:
   # This follows semver recommendations, with release candidates having a dash and a dot
   # @see https://semver.org/spec/v2.0.0-rc.2.html
   check-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       release_status_output: ${{ steps.release_version.outputs.version_status_output }}
 
@@ -47,7 +47,7 @@ jobs:
 
   # Initiate upload only if the version is valid
   upload-apidocs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
     needs: check-version

--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -7,7 +7,7 @@ on:
       - release
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   itest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   itest:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 80
 
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
       - release
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     timeout-minutes: 40 # default is 360
     strategy:
       matrix:


### PR DESCRIPTION
### Motivation

ubuntu 20 was deprecated as a runner and some actions that use it are not running anymore.

### Acceptance Criteria
- Update runners to use ubuntu latest


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
