### PR TITLE
fix: regenerate lavamoat policy for Docker compatibility

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,56 @@
+name: docker-smoke-test
+on:
+  push:
+    branches:
+      - master
+      - release-candidate
+      - release
+  pull_request:
+    branches:
+      - master
+      - release-candidate
+      - release
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build Docker image
+        run: docker build -t hathor-wallet-headless .
+
+      - name: Start container
+        run: |
+          docker run -d --name headless-test \
+            -p 8000:8000 \
+            -e HEADLESS_NETWORK=testnet \
+            -e HEADLESS_SERVER=https://node1.testnet.hathor.network/v1a/ \
+            -e HEADLESS_SEED_DEFAULT="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" \
+            -e HEADLESS_API_KEY=ci_test_key \
+            hathor-wallet-headless
+
+      - name: Wait for service to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -H "X-API-KEY: ci_test_key" http://localhost:8000/wallet/status > /dev/null 2>&1; then
+              echo "Service is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Service failed to start"
+          docker logs headless-test
+          exit 1
+
+      - name: Verify API responds
+        run: |
+          RESPONSE=$(curl -s -H "X-API-KEY: ci_test_key" http://localhost:8000/wallet/status)
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | grep -q "X-Wallet-Id"
+
+      - name: Stop container
+        if: always()
+        run: docker stop headless-test || true

--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,8 @@ xpub_from_seed: .script-build-dirs .run_xpub_from_seed .script-clean-dirs
 # Command: Derive multisig xPub from seed
 .PHONY: multisig_xpub_from_seed
 multisig_xpub_from_seed: .script-build-dirs .run_multisig_xpub_from_seed .script-clean-dirs
+
+# Command: Regenerate LavaMoat policy from production dependencies
+.PHONY: lavamoat_policy
+lavamoat_policy:
+	bash scripts/generate-lavamoat-policy.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,76 @@ A **headless wallet** is a wallet application whose interface is an API.
 
 To know how to operate and use Hathor headless wallet, see [Hathor headless wallet at Hathor docs — official technical documentation of Hathor](https://docs.hathor.network/pathways/components/headless-wallet).
 
+### Running with Docker
+
+The easiest way to run the headless wallet is with Docker. Pre-built images are available on [Docker Hub](https://hub.docker.com/r/hathornetwork/hathor-wallet-headless):
+
+```bash
+docker run -p 8000:8000 --env-file .env.headless hathornetwork/hathor-wallet-headless
+```
+
+Where `.env.headless` contains your configuration (do not commit this file):
+
+```
+HEADLESS_NETWORK=mainnet
+HEADLESS_SERVER=https://node1.mainnet.hathor.network/v1a/
+HEADLESS_SEED_DEFAULT=your seed words here
+HEADLESS_API_KEY=your_api_key
+```
+
+### Running from source
+
+Requirements: Node.js >= 22.0.0, npm >= 10.0.0.
+
+```bash
+# Install all dependencies (needed for the build step)
+npm ci
+
+# Copy and edit the configuration file
+cp config.js.template config.js
+# Edit config.js with your settings (seed, network, server, etc.)
+
+# Build the project
+npm run build
+
+# Remove dev dependencies so the runtime matches the LavaMoat policy
+rm -rf node_modules
+npm ci --only=production
+
+# Run
+npm run start:lavamoat
+```
+
+> **Note:** The [LavaMoat](https://github.com/LavaMoat/LavaMoat) security policy is generated against production dependencies. Dev dependencies change the dependency resolution paths, causing policy violations at runtime. That's why dev dependencies must be removed after building.
+
+### Development
+
+For local development without LavaMoat:
+
+```bash
+npm ci
+cp config.js.template config.js
+# Edit config.js with your settings
+
+# Run without LavaMoat (uses nodemon for auto-reload)
+npm run dev
+
+# Or build and run without LavaMoat
+npm run start
+```
+
+To test with LavaMoat locally, follow the [Running from source](#running-from-source) steps above.
+
+### Regenerating the LavaMoat policy
+
+When dependencies change, the LavaMoat policy must be regenerated. Use the provided script that generates the policy against production dependencies inside Docker:
+
+```bash
+make lavamoat_policy
+```
+
+This requires Docker to be running. The script builds the project with the Docker config, spins up a container with production-only `node_modules`, and runs `lavamoat --autopolicy` inside it.
+
 ## Support
 
 If after consulting the documentation, you still need **help to operate and use Hathor headless wallet**, [send a message to the `#development` channel on Hathor Discord server for assistance from Hathor team and community members](https://discord.com/channels/566500848570466316/663785995082268713).

--- a/lavamoat/node/policy.json
+++ b/lavamoat/node/policy.json
@@ -89,6 +89,11 @@
         "express>accepts>negotiator": true
       }
     },
+    "yargs>cliui>wrap-ansi>ansi-styles": {
+      "packages": {
+        "yargs>cliui>wrap-ansi>ansi-styles>color-convert": true
+      }
+    },
     "winston>async": {
       "globals": {
         "process": true,
@@ -128,16 +133,16 @@
         "Response": true,
         "TextEncoder": true,
         "URL": true,
-        "WorkerGlobalScope": true,
-        "XMLHttpRequest": true,
+        "WorkerGlobalScope": false,
+        "XMLHttpRequest": false,
         "btoa": true,
         "clearTimeout": true,
         "console.warn": true,
-        "document": true,
+        "document": false,
         "fetch": true,
-        "importScripts": true,
-        "location.href": true,
-        "navigator": true,
+        "importScripts": false,
+        "location.href": false,
+        "navigator": false,
         "process": true,
         "queueMicrotask": true,
         "setImmediate": true,
@@ -256,18 +261,33 @@
         "buffer.SlowBuffer.prototype.equal": true
       }
     },
-    "eslint-plugin-import>object.values>call-bind>call-bind-apply-helpers": {
+    "express>qs>side-channel>call-bind>call-bind-apply-helpers": {
       "packages": {
-        "eslint-plugin-import>array.prototype.findlastindex>es-errors": true,
-        "eslint-plugin-import>hasown>function-bind": true
+        "express>qs>side-channel>get-intrinsic>es-errors": true,
+        "express>qs>side-channel>get-intrinsic>function-bind": true
       }
     },
-    "eslint-plugin-import>object.values>call-bind": {
+    "express>qs>side-channel>call-bind": {
       "packages": {
-        "eslint-plugin-import>object.values>call-bind>call-bind-apply-helpers": true,
-        "eslint-plugin-import>object.values>call-bind>es-define-property": true,
-        "eslint-plugin-import>array-includes>get-intrinsic": true,
-        "eslint-plugin-import>object.values>call-bind>set-function-length": true
+        "express>qs>side-channel>call-bind>call-bind-apply-helpers": true,
+        "express>qs>side-channel>call-bind>es-define-property": true,
+        "express>qs>side-channel>get-intrinsic": true,
+        "express>qs>side-channel>call-bind>set-function-length": true
+      }
+    },
+    "yargs>cliui": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "yargs>string-width": true,
+        "yargs>cliui>strip-ansi": true,
+        "yargs>cliui>wrap-ansi": true
+      }
+    },
+    "yargs>cliui>wrap-ansi>ansi-styles>color-convert": {
+      "packages": {
+        "yargs>cliui>wrap-ansi>ansi-styles>color-convert>color-name": true
       }
     },
     "winston>@dabh/diagnostics>colorspace>color>color-convert": {
@@ -338,22 +358,22 @@
         "util": true
       },
       "globals": {
-        "chrome": true,
+        "chrome": false,
         "console": true,
-        "document": true,
-        "localStorage": true,
-        "navigator": true,
+        "document": false,
+        "localStorage": false,
+        "navigator": false,
         "process": true
       },
       "packages": {
         "morgan>debug>ms": true
       }
     },
-    "eslint-plugin-import>object.values>define-properties>define-data-property": {
+    "express>qs>side-channel>call-bind>set-function-length>define-data-property": {
       "packages": {
-        "eslint-plugin-import>object.values>call-bind>es-define-property": true,
-        "eslint-plugin-import>array.prototype.findlastindex>es-errors": true,
-        "eslint-plugin-import>array-includes>es-abstract>gopd": true
+        "express>qs>side-channel>call-bind>es-define-property": true,
+        "express>qs>side-channel>get-intrinsic>es-errors": true,
+        "express>qs>side-channel>get-intrinsic>gopd": true
       }
     },
     "axios>form-data>combined-stream>delayed-stream": {
@@ -391,10 +411,10 @@
         "zlib.Unzip": true
       }
     },
-    "eslint-plugin-import>array-includes>get-intrinsic>get-proto>dunder-proto": {
+    "express>qs>side-channel>get-intrinsic>get-proto>dunder-proto": {
       "packages": {
-        "eslint-plugin-import>object.values>call-bind>call-bind-apply-helpers": true,
-        "eslint-plugin-import>array-includes>es-abstract>gopd": true
+        "express>qs>side-channel>call-bind>call-bind-apply-helpers": true,
+        "express>qs>side-channel>get-intrinsic>gopd": true
       }
     },
     "jsonwebtoken>jws>jwa>ecdsa-sig-formatter": {
@@ -411,6 +431,14 @@
         "express>http-errors>inherits": true,
         "@hathor/wallet-lib>bitcore-lib>elliptic>minimalistic-assert": true,
         "@hathor/wallet-lib>bitcore-lib>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "yargs>escalade": {
+      "builtin": {
+        "fs.readdirSync": true,
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.resolve": true
       }
     },
     "express>etag": {
@@ -554,7 +582,7 @@
         "axios>form-data>mime-types": true
       }
     },
-    "eslint-plugin-import>array-includes>get-intrinsic": {
+    "express>qs>side-channel>get-intrinsic": {
       "globals": {
         "AggregateError": true,
         "FinalizationRegistry": true,
@@ -562,27 +590,27 @@
         "WeakRef": true
       },
       "packages": {
-        "eslint-plugin-import>object.values>call-bind>call-bind-apply-helpers": true,
-        "eslint-plugin-import>object.values>call-bind>es-define-property": true,
-        "eslint-plugin-import>array.prototype.findlastindex>es-errors": true,
-        "eslint-plugin-import>object.values>es-object-atoms": true,
-        "eslint-plugin-import>hasown>function-bind": true,
-        "eslint-plugin-import>array-includes>get-intrinsic>get-proto": true,
-        "eslint-plugin-import>array-includes>es-abstract>gopd": true,
-        "eslint-config-airbnb-base>object.assign>has-symbols": true,
-        "eslint-plugin-import>hasown": true,
-        "eslint-plugin-import>array-includes>get-intrinsic>math-intrinsics": true
+        "express>qs>side-channel>call-bind>call-bind-apply-helpers": true,
+        "express>qs>side-channel>call-bind>es-define-property": true,
+        "express>qs>side-channel>get-intrinsic>es-errors": true,
+        "express>qs>side-channel>get-intrinsic>es-object-atoms": true,
+        "express>qs>side-channel>get-intrinsic>function-bind": true,
+        "express>qs>side-channel>get-intrinsic>get-proto": true,
+        "express>qs>side-channel>get-intrinsic>gopd": true,
+        "express>qs>side-channel>get-intrinsic>has-symbols": true,
+        "lavamoat>resolve>is-core-module>hasown": true,
+        "express>qs>side-channel>get-intrinsic>math-intrinsics": true
       }
     },
-    "eslint-plugin-import>array-includes>get-intrinsic>get-proto": {
+    "express>qs>side-channel>get-intrinsic>get-proto": {
       "packages": {
-        "eslint-plugin-import>array-includes>get-intrinsic>get-proto>dunder-proto": true,
-        "eslint-plugin-import>object.values>es-object-atoms": true
+        "express>qs>side-channel>get-intrinsic>get-proto>dunder-proto": true,
+        "express>qs>side-channel>get-intrinsic>es-object-atoms": true
       }
     },
-    "eslint-plugin-import>object.values>define-properties>has-property-descriptors": {
+    "express>qs>side-channel>call-bind>set-function-length>has-property-descriptors": {
       "packages": {
-        "eslint-plugin-import>object.values>call-bind>es-define-property": true
+        "express>qs>side-channel>call-bind>es-define-property": true
       }
     },
     "@hathor/wallet-lib>bitcore-lib>elliptic>hash.js": {
@@ -591,9 +619,9 @@
         "@hathor/wallet-lib>bitcore-lib>elliptic>minimalistic-assert": true
       }
     },
-    "eslint-plugin-import>hasown": {
+    "lavamoat>resolve>is-core-module>hasown": {
       "packages": {
-        "eslint-plugin-import>hasown>function-bind": true
+        "express>qs>side-channel>get-intrinsic>function-bind": true
       }
     },
     "@hathor/wallet-lib>bitcore-lib>elliptic>hmac-drbg": {
@@ -645,7 +673,7 @@
     },
     "@hathor/wallet-lib>isomorphic-ws": {
       "packages": {
-        "@hathor/wallet-lib>ws": true
+        "ws": true
       }
     },
     "jsonwebtoken": {
@@ -722,9 +750,9 @@
         "winston>triple-beam": true
       }
     },
-    "nodemon>semver>lru-cache": {
+    "jsonwebtoken>semver>lru-cache": {
       "packages": {
-        "nodemon>semver>lru-cache>yallist": true
+        "jsonwebtoken>semver>lru-cache>yallist": true
       }
     },
     "express>methods": {
@@ -908,6 +936,15 @@
         "winston>readable-stream>util-deprecate": true
       }
     },
+    "yargs>require-directory": {
+      "builtin": {
+        "fs.readdirSync": true,
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
+      }
+    },
     "morgan>basic-auth>safe-buffer": {
       "builtin": {
         "buffer": true
@@ -937,7 +974,7 @@
         "process": true
       },
       "packages": {
-        "nodemon>semver>lru-cache": true
+        "jsonwebtoken>semver>lru-cache": true
       }
     },
     "express>send": {
@@ -986,19 +1023,19 @@
         "express>send": true
       }
     },
-    "eslint-plugin-import>object.values>call-bind>set-function-length": {
+    "express>qs>side-channel>call-bind>set-function-length": {
       "packages": {
-        "eslint-plugin-import>object.values>define-properties>define-data-property": true,
-        "eslint-plugin-import>array.prototype.findlastindex>es-errors": true,
-        "eslint-plugin-import>array-includes>get-intrinsic": true,
-        "eslint-plugin-import>array-includes>es-abstract>gopd": true,
-        "eslint-plugin-import>object.values>define-properties>has-property-descriptors": true
+        "express>qs>side-channel>call-bind>set-function-length>define-data-property": true,
+        "express>qs>side-channel>get-intrinsic>es-errors": true,
+        "express>qs>side-channel>get-intrinsic": true,
+        "express>qs>side-channel>get-intrinsic>gopd": true,
+        "express>qs>side-channel>call-bind>set-function-length>has-property-descriptors": true
       }
     },
     "express>qs>side-channel": {
       "packages": {
-        "eslint-plugin-import>object.values>call-bind": true,
-        "eslint-plugin-import>array-includes>get-intrinsic": true,
+        "express>qs>side-channel>call-bind": true,
+        "express>qs>side-channel>get-intrinsic": true,
         "express>qs>side-channel>object-inspect": true
       }
     },
@@ -1007,9 +1044,31 @@
         "winston>@dabh/diagnostics>colorspace>color>color-string>simple-swizzle>is-arrayish": true
       }
     },
+    "yargs>string-width": {
+      "packages": {
+        "yargs>string-width>emoji-regex": true,
+        "yargs>string-width>is-fullwidth-code-point": true,
+        "yargs>string-width>strip-ansi": true
+      }
+    },
     "winston>readable-stream>string_decoder": {
       "packages": {
         "morgan>basic-auth>safe-buffer": true
+      }
+    },
+    "yargs>cliui>strip-ansi": {
+      "packages": {
+        "yargs>cliui>strip-ansi>ansi-regex": true
+      }
+    },
+    "yargs>string-width>strip-ansi": {
+      "packages": {
+        "yargs>string-width>strip-ansi>ansi-regex": true
+      }
+    },
+    "yargs>cliui>wrap-ansi>strip-ansi": {
+      "packages": {
+        "yargs>cliui>wrap-ansi>strip-ansi>ansi-regex": true
       }
     },
     "express>type-is": {
@@ -1048,8 +1107,8 @@
         "fs.rename": true,
         "fs.stat": true,
         "fs.unlink": true,
-        "http": true,
-        "https": true,
+        "http": false,
+        "https": false,
         "os.EOL": true,
         "os.loadavg": true,
         "os.uptime": true,
@@ -1075,7 +1134,7 @@
         "process.argv": true,
         "process.cwd": true,
         "process.execPath": true,
-        "process.exit": true,
+        "process.exit": false,
         "process.getgid": true,
         "process.getuid": true,
         "process.memoryUsage": true,
@@ -1112,7 +1171,14 @@
         "winston>triple-beam": true
       }
     },
-    "@hathor/wallet-lib>ws": {
+    "yargs>cliui>wrap-ansi": {
+      "packages": {
+        "yargs>cliui>wrap-ansi>ansi-styles": true,
+        "yargs>string-width": true,
+        "yargs>cliui>wrap-ansi>strip-ansi": true
+      }
+    },
+    "ws": {
       "builtin": {
         "buffer.isUtf8": true,
         "crypto.createHash": true,
@@ -1136,6 +1202,7 @@
         "zlib.createInflateRaw": true
       },
       "globals": {
+        "Blob": true,
         "Buffer": true,
         "clearTimeout": true,
         "process.env.WS_NO_BUFFER_UTIL": true,
@@ -1143,6 +1210,51 @@
         "process.nextTick": true,
         "setImmediate": true,
         "setTimeout": true
+      }
+    },
+    "yargs>y18n": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "fs.writeFile": true,
+        "path.resolve": true,
+        "util.format": true
+      }
+    },
+    "yargs": {
+      "builtin": {
+        "assert.notStrictEqual": true,
+        "assert.strictEqual": true,
+        "fs.readFileSync": true,
+        "path": true,
+        "util.inspect": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.error": true,
+        "console.log": true,
+        "console.warn": true,
+        "process": true
+      },
+      "packages": {
+        "yargs>cliui": true,
+        "yargs>escalade": true,
+        "yargs>get-caller-file": true,
+        "yargs>require-directory": true,
+        "yargs>string-width": true,
+        "yargs>y18n": true,
+        "yargs>yargs-parser": true
+      }
+    },
+    "yargs>yargs-parser": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.normalize": true,
+        "path.resolve": true,
+        "util.format": true
+      },
+      "globals": {
+        "process": true
       }
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dev": "nodemon --exec babel-node src/index.js",
     "start": "npm run build && node dist/index.js",
     "start:lavamoat": "npm run build && lavamoat dist/index.js",
-    "lavamoat:policy": "npm run build && lavamoat dist/index.js --autopolicy",
     "test": "jest --forceExit  --runInBand",
     "test_integration": "npm run test_network_up && npm run test_network_integration && npm run test_network_down",
     "test_network_up": "docker compose -f ./__tests__/integration/docker-compose.yml up -d && mkdir -p tmp && cp ./__tests__/integration/configuration/precalculated-wallets.json ./tmp/wallets.json",

--- a/scripts/generate-lavamoat-policy.sh
+++ b/scripts/generate-lavamoat-policy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Generates the LavaMoat policy from production dependencies.
+#
+# The policy must be generated against production node_modules (not dev) because
+# npm resolves transitive dependencies differently when devDependencies are
+# installed. Additionally, config.js is loaded dynamically at runtime, so we use
+# a shim entrypoint that statically requires it so lavamoat discovers its
+# dependency tree (yargs, etc.).
+#
+# Requirements: Docker
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+echo "==> Installing dependencies (including dev for build)..."
+npm ci --silent
+
+echo "==> Building with config.js.docker as config source..."
+cp config.js.docker src/config.js
+npm run build --silent
+rm src/config.js
+
+echo "==> Building Docker deps stage (production node_modules)..."
+docker build --target deps -t hathor-headless-deps . -q
+
+echo "==> Generating LavaMoat policy inside container..."
+SHIM=$(mktemp)
+cat > "$SHIM" << 'EOF'
+require("./dist/index.js");
+require("./dist/config.js");
+EOF
+
+docker run --rm \
+  -v "$PROJECT_DIR/lavamoat:/usr/src/app/lavamoat" \
+  -v "$PROJECT_DIR/dist:/usr/src/app/dist" \
+  -v "$SHIM:/usr/src/app/lavamoat-entry.js" \
+  hathor-headless-deps \
+  sh -c "./node_modules/.bin/lavamoat lavamoat-entry.js --autopolicy" 2>&1
+
+rm -f "$SHIM"
+
+echo "==> Done. Policy written to lavamoat/node/policy.json"


### PR DESCRIPTION
### Acceptance Criteria
- [x] Docker image starts successfully with lavamoat entrypoint
- [x] Running from source with production deps works with lavamoat
- [x] `make lavamoat_policy` regenerates the policy correctly
- [x] README documents how to run (Docker, from source, dev) and how to regenerate the policy

### What this PR does

The LavaMoat policy was out of date and the Docker image could not start. Two root causes:

1. The policy was generated against dev `node_modules`, but the runtime (Docker and recommended from-source setup) uses production-only deps. npm resolves shared transitive packages through different parent chains in each case, so the policy didn't match.
2. `settings.js` loads `config.js` via a dynamic `import()`, so lavamoat's static analysis never discovered `yargs` and its transitive deps (used in `config.js.docker`).

This PR:
- Regenerates `policy.json` from production dependencies, using a shim entrypoint that statically requires `config.js` so lavamoat sees the full dependency graph.
- Adds `scripts/generate-lavamoat-policy.sh` and a `make lavamoat_policy` target to automate policy regeneration (requires Docker). `npm run lavamoat:policy` should no longer be used.
- Adds README sections for running with Docker, running from source, development, and regenerating the policy.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.