### PR TITLE
chore: bump version to v0.39.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.38.0",
+  "version": "0.39.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-wallet-headless",
-      "version": "0.38.0",
+      "version": "0.39.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.38.0",
+  "version": "0.39.0-rc.1",
   "description": "Hathor Wallet Headless, i.e., without graphical user interface",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Bump version to `v0.39.0-rc.1` on the `release-candidate` branch.