### PR TITLE
fix: initialize plugin child logger after config setup

### DIFF
--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -1,0 +1,24 @@
+describe('buildAppLogger', () => {
+  it('throws a descriptive error when called before config initialization', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      const { buildAppLogger } = require('../src/logger');
+
+      expect(() => buildAppLogger()).toThrow(
+        /buildLogger requires an initialized config/,
+      );
+    });
+  });
+
+  it('returns the cached logger on subsequent calls even when no config is passed', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      const { buildAppLogger } = require('../src/logger');
+
+      const first = buildAppLogger({ consoleLevel: 'info' });
+      const second = buildAppLogger();
+
+      expect(second).toBe(first);
+    });
+  });
+});

--- a/src/logger.js
+++ b/src/logger.js
@@ -21,6 +21,9 @@ let logger = null;
  * @return {winston.Logger}
  */
 function buildLogger(config, defaultService) {
+  if (!config) {
+    throw new Error('buildLogger requires an initialized config; call settings.setupConfig() before building the logger.');
+  }
   const myFormat = winston.format.printf(({ level, message, service, timestamp, ...args }) => {
     let argsStr = '';
     if (Object.keys(args).length > 0) {

--- a/src/plugins/child.js
+++ b/src/plugins/child.js
@@ -104,6 +104,8 @@ export const loadPlugins = async (enabled, customConfig) => {
 export const main = async () => {
   await settings.setupConfig();
   const config = settings.getConfig();
+  const logger = buildAppLogger(config);
+  logger.info('[child_process] startup');
   const plugins = await loadPlugins(config.enabled_plugins, config.plugin_config);
 
   // Start plugins
@@ -138,7 +140,5 @@ if (process.env.NODE_ENV !== 'test') {
 
   process.on('message', handleMessage);
 
-  const logger = buildAppLogger();
-  logger.info('[child_process] startup');
   main();
 }


### PR DESCRIPTION
### Root Cause

When `enabled_plugins` is non-empty, `src/index.js` forks `src/plugins/child.js` to run plugins in a separate process. That child entry point was building its app logger at module top-level — **before** `settings.setupConfig()` had a chance to run inside `main()`:

```js
// src/plugins/child.js (before)
if (process.env.NODE_ENV !== 'test') {
  process.on('disconnect', () => { ... });
  process.on('message', handleMessage);

  const logger = buildAppLogger();   // <- runs before setupConfig
  logger.info('[child_process] startup');
  main();                             // <- only here setupConfig() is awaited
}
```

`buildAppLogger()` was called without a `config` argument and forwarded `undefined` into `buildLogger`, which dereferenced `config.consoleLevel` and crashed the child immediately:

```
TypeError: Cannot read properties of undefined (reading 'consoleLevel')
    at buildLogger (src/logger.js:45:21)
    at buildAppLogger (src/logger.js:84:21)
    at Object.<anonymous> (src/plugins/child.js:141:32)
...
[wallet] info: child process exited with code 1 or due to signal null.
[nodemon] app crashed - waiting for file changes before starting...
```

The parent process kept the HTTP API up, but **no plugin (ws, sqs, rabbitmq, debug) ever loaded** — the child died on startup every time. This regression affected every deployment with `enabled_plugins` configured.

### Fix

- Move `buildAppLogger(config)` into `main()` right after `await settings.setupConfig()`, so the logger is built with the real config and the module-level cache in `src/logger.js` is properly seeded for subsequent unargumented calls (including the `disconnect` handler and the `loadPlugins` warning path).
- Add an explicit guard in `buildLogger` that throws a clear, named error when called without a config, replacing the cryptic `Cannot read properties of undefined` stack with: `buildLogger requires an initialized config; call settings.setupConfig() before building the logger.`

### Acceptance Criteria

- Starting the headless wallet with `enabled_plugins: ['ws']` in `src/config.js` no longer crashes the child process; logs show `[child_process] startup` followed by `plugin[ws]: loaded`.
- WebSocket clients can successfully connect to the WS plugin port (`ws://localhost:8008` by default).
- The parent's HTTP API continues to serve normally on the configured `http_port`.
- Calling `buildLogger` (directly or via `buildAppLogger`) before `settings.setupConfig()` throws an explicit, descriptive error instead of the previous `Cannot read properties of undefined (reading 'consoleLevel')` crash.
- Other enabled plugins (`sqs`, `rabbitmq`, `debug`) load through the same code path and benefit from the fix without any code change in the plugin modules themselves.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logger initialization now requires configuration and gives a clear error if attempted before setup.
  * Startup flow updated to load configuration before creating logger instances.
  * Redundant startup logging removed to avoid duplicate messages.

* **Tests**
  * Added tests to verify logger errors when uninitialized and to ensure subsequent logger calls reuse the same instance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-headless/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->