### PR TITLE
feat(wallet): add POST /wallet/sign-message endpoint

### DIFF
--- a/__tests__/integration/sign-message.test.js
+++ b/__tests__/integration/sign-message.test.js
@@ -1,5 +1,6 @@
 import { cryptoUtils } from '@hathor/wallet-lib';
 import { TestUtils } from './utils/test-utils-integration';
+import { WALLET_CONSTANTS } from './configuration/test-constants';
 import { WalletHelper } from './utils/wallet-helper';
 
 /*
@@ -94,12 +95,10 @@ describe('sign-message route', () => {
   });
 
   it('rejects when the address is not in the wallet', async () => {
-    // A clearly out-of-band address — syntactically valid but not derivable
-    // from this wallet. We borrow another precalculated wallet's address-0 to
-    // avoid hand-constructing one; we don't start the second wallet because we
-    // only need its first cached address.
-    const foreignWallet = WalletHelper.getPrecalculatedWallet('sign-message-other');
-    const foreignAddress = foreignWallet.addresses[0];
+    // A known-valid address from a different seed (the miner wallet), so it is
+    // guaranteed not derivable from this wallet — cheaper than spinning up a
+    // whole second wallet just to borrow an address.
+    const foreignAddress = WALLET_CONSTANTS.miner.addresses[1];
 
     const response = await TestUtils.request
       .post('/wallet/sign-message')

--- a/__tests__/integration/sign-message.test.js
+++ b/__tests__/integration/sign-message.test.js
@@ -1,0 +1,145 @@
+import { cryptoUtils } from '@hathor/wallet-lib';
+import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
+
+/*
+ * Integration coverage for POST /wallet/sign-message.
+ *
+ * The endpoint accepts either `address_index` or `address` and returns a
+ * bitcore.Message-compatible signature plus the resolved {address, index}.
+ * Verification on the consumer side uses the wallet-lib's `verifyMessage`
+ * primitive — we use it here directly to assert the returned signature is
+ * valid for the resolved address.
+ */
+describe('sign-message route', () => {
+  let wallet;
+
+  beforeAll(async () => {
+    try {
+      wallet = WalletHelper.getPrecalculatedWallet('sign-message-1');
+      await WalletHelper.startMultipleWalletsForTest([wallet]);
+    } catch (err) {
+      TestUtils.logError(err.stack);
+    }
+  });
+
+  afterAll(async () => {
+    await wallet.stop();
+  });
+
+  it('signs a message using address_index and returns a verifiable signature', async () => {
+    const message = 'x402:request:abc123';
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message, address_index: 0 })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.index).toBe(0);
+    expect(typeof response.body.signature).toBe('string');
+    expect(response.body.signature.length).toBeGreaterThan(0);
+
+    const expectedAddress = await wallet.getAddressAt(0);
+    expect(response.body.address).toBe(expectedAddress);
+
+    // Verify the signature with wallet-lib's verifyMessage. The endpoint is
+    // useless if the signature can't be checked off the wire — assert it.
+    expect(
+      cryptoUtils.verifyMessage(message, response.body.signature, response.body.address)
+    ).toBe(true);
+  });
+
+  it('signs a message using address and returns a verifiable signature', async () => {
+    const message = 'x402:request:xyz789';
+    const targetAddress = await wallet.getAddressAt(3);
+
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message, address: targetAddress })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.address).toBe(targetAddress);
+    expect(response.body.index).toBe(3);
+    expect(typeof response.body.signature).toBe('string');
+
+    expect(
+      cryptoUtils.verifyMessage(message, response.body.signature, response.body.address)
+    ).toBe(true);
+  });
+
+  it('prefers address_index when both address and address_index are sent', async () => {
+    // Documented contract: when both are passed, `address_index` wins, and the
+    // response address is derived from the index actually used to sign (so the
+    // returned {address, signature} pair always verifies).
+    const message = 'x402:request:both';
+    const otherAddress = await wallet.getAddressAt(5);
+    const indexAddress = await wallet.getAddressAt(1);
+
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message, address_index: 1, address: otherAddress })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.index).toBe(1);
+    expect(response.body.address).toBe(indexAddress);
+
+    expect(
+      cryptoUtils.verifyMessage(message, response.body.signature, response.body.address)
+    ).toBe(true);
+  });
+
+  it('rejects when the address is not in the wallet', async () => {
+    // A clearly out-of-band address — syntactically valid but not derivable
+    // from this wallet. We borrow another precalculated wallet's address-0 to
+    // avoid hand-constructing one; we don't start the second wallet because we
+    // only need its first cached address.
+    const foreignWallet = WalletHelper.getPrecalculatedWallet('sign-message-other');
+    const foreignAddress = foreignWallet.addresses[0];
+
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message: 'whatever', address: foreignAddress })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/does not belong/i);
+  });
+
+  it('rejects when neither address nor address_index is provided', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message: 'no key chosen' })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/required/i);
+  });
+
+  it('rejects an empty message', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message: '', address_index: 0 })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    // express-validator rejects with 400 because of isLength({min: 1}).
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('rejects a negative address_index', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message: 'hi', address_index: -1 })
+      .set({ 'x-wallet-id': wallet.walletId });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+});

--- a/__tests__/integration/sign-message.test.js
+++ b/__tests__/integration/sign-message.test.js
@@ -15,16 +15,16 @@ describe('sign-message route', () => {
   let wallet;
 
   beforeAll(async () => {
-    try {
-      wallet = WalletHelper.getPrecalculatedWallet('sign-message-1');
-      await WalletHelper.startMultipleWalletsForTest([wallet]);
-    } catch (err) {
-      TestUtils.logError(err.stack);
-    }
+    // Let a startup failure surface — swallowing it leaves `wallet` unset and
+    // produces a confusing secondary error in afterAll that masks the real cause.
+    wallet = WalletHelper.getPrecalculatedWallet('sign-message-1');
+    await WalletHelper.startMultipleWalletsForTest([wallet]);
   });
 
   afterAll(async () => {
-    await wallet.stop();
+    if (wallet) {
+      await wallet.stop();
+    }
   });
 
   it('signs a message using address_index and returns a verifiable signature', async () => {

--- a/__tests__/sign-message.test.js
+++ b/__tests__/sign-message.test.js
@@ -1,0 +1,51 @@
+import TestUtils from './test-utils';
+import { initializedWallets } from '../src/services/wallets.service';
+
+const walletId = 'stub_sign_message';
+
+describe('sign-message api', () => {
+  beforeAll(async () => {
+    await TestUtils.startWallet({ walletId });
+  });
+
+  afterAll(async () => {
+    await TestUtils.stopWallet({ walletId });
+  });
+
+  it('should sign a message with a valid address_index', async () => {
+    const response = await TestUtils.request
+      .post('/wallet/sign-message')
+      .send({ message: 'hello', address_index: 0 })
+      .set({ 'x-wallet-id': walletId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.index).toBe(0);
+    expect(typeof response.body.signature).toBe('string');
+  });
+
+  it('should surface a contextual error when signing throws', async () => {
+    // The generic catch block can only be reached by an internally-thrown
+    // error (key derivation / signing), which integration tests can't force.
+    // Mock the wallet instance the controller uses so signing rejects.
+    const wallet = initializedWallets.get(walletId);
+    const spy = jest
+      .spyOn(wallet, 'signMessageWithAddress')
+      .mockRejectedValueOnce(new Error('boom from lib'));
+
+    try {
+      const response = await TestUtils.request
+        .post('/wallet/sign-message')
+        .send({ message: 'hello', address_index: 0 })
+        .set({ 'x-wallet-id': walletId });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(false);
+      // The handler prefixes the underlying message so the caller knows which
+      // operation failed, and still surfaces the original cause.
+      expect(response.body.error).toBe('failed to sign message: boom from lib');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -683,6 +683,76 @@ const defaultApiDocs = {
         },
       },
     },
+    '/wallet/sign-message': {
+      post: {
+        operationId: 'signMessage',
+        summary: 'Sign an arbitrary message with one of the wallet\'s address keys.',
+        description: 'Returns a Bitcoin-compatible signed-message signature (bitcore.Message). Useful for off-chain proofs of address ownership — e.g., the x402 payment protocol requires signing a server-issued challenge with the payer\'s key. Either `address_index` or `address` must be provided; if both are given, `address_index` wins.',
+        parameters: [
+          { $ref: '#/components/parameters/XWalletIdParameter' },
+        ],
+        requestBody: {
+          description: 'Message and key to sign with.',
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['message'],
+                properties: {
+                  message: {
+                    type: 'string',
+                    description: 'The payload to sign. Any UTF-8 string.',
+                  },
+                  address_index: {
+                    type: 'integer',
+                    minimum: 0,
+                    description: 'Derivation index of the wallet address that will sign.',
+                  },
+                  address: {
+                    type: 'string',
+                    description: 'Alternative to `address_index` — wallet resolves it via getAddressIndex.',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'Returns the signature.',
+            content: {
+              'application/json': {
+                examples: {
+                  success: {
+                    summary: 'Success',
+                    value: {
+                      success: true,
+                      signature: 'H2Wf3GntZdrZsR4N6vLm8Zr5e4D1KH...=',
+                      address: 'H8bt9nYhUNJHg7szF32CWWi1eB8PyYZnbt',
+                      index: 5,
+                    },
+                  },
+                  'missing-key': {
+                    summary: 'Neither address_index nor address provided',
+                    value: { success: false, error: 'one of address_index or address is required' },
+                  },
+                  'address-not-in-wallet': {
+                    summary: 'The supplied address is not derivable from this wallet',
+                    value: { success: false, error: 'address does not belong to the wallet' },
+                  },
+                  'wallet-not-ready': {
+                    summary: 'Wallet is not ready yet',
+                    value: { success: false, message: 'Wallet is not ready.', state: 1 },
+                  },
+                  ...commonExamples.xWalletIdErrResponseExamples,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     '/wallet/addresses': {
       get: {
         operationId: 'getAddresses',

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -699,10 +699,18 @@ const defaultApiDocs = {
               schema: {
                 type: 'object',
                 required: ['message'],
+                // `message` is always required; in addition, at least one of
+                // `address_index` or `address` must be present. If both are
+                // sent, `address_index` wins.
+                anyOf: [
+                  { required: ['address_index'] },
+                  { required: ['address'] },
+                ],
                 properties: {
                   message: {
                     type: 'string',
-                    description: 'The payload to sign. Any UTF-8 string.',
+                    minLength: 1,
+                    description: 'The payload to sign. Any non-empty UTF-8 string.',
                   },
                   address_index: {
                     type: 'integer',
@@ -746,6 +754,33 @@ const defaultApiDocs = {
                     value: { success: false, message: 'Wallet is not ready.', state: 1 },
                   },
                   ...commonExamples.xWalletIdErrResponseExamples,
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Request body failed validation (e.g. empty `message` or negative `address_index`).',
+            content: {
+              'application/json': {
+                examples: {
+                  'empty-message': {
+                    summary: 'Empty message',
+                    value: {
+                      success: false,
+                      error: [{
+                        type: 'field', value: '', msg: 'Invalid value', path: 'message', location: 'body',
+                      }],
+                    },
+                  },
+                  'negative-address-index': {
+                    summary: 'Negative address_index',
+                    value: {
+                      success: false,
+                      error: [{
+                        type: 'field', value: -1, msg: 'Invalid value', path: 'address_index', location: 'body',
+                      }],
+                    },
+                  },
                 },
               },
             },

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -187,7 +187,10 @@ async function signMessage(req, res) {
     const resolvedAddress = await wallet.getAddressAtIndex(index);
     res.send({ success: true, signature, address: resolvedAddress, index });
   } catch (err) {
-    res.send({ success: false, error: err.message });
+    // An underlying call (key derivation, signing) may throw an error that has
+    // nothing to do with message signing on its face — prefix it so the HTTP
+    // caller knows which operation failed.
+    res.send({ success: false, error: `failed to sign message: ${err.message}` });
   }
 }
 

--- a/src/controllers/wallet/wallet.controller.js
+++ b/src/controllers/wallet/wallet.controller.js
@@ -14,6 +14,7 @@ const { friendlyWalletState, cantSendTxErrorMessage } = require('../../helpers/c
 const { mapTxReturn, prepareTxFunds, getTx, markUtxosSelectedAsInput, runSendTransaction } = require('../../helpers/tx.helper');
 const { stopWallet } = require('../../services/wallets.service');
 const { lockSendTx } = require('../../helpers/lock.helper');
+const { DEFAULT_PIN } = require('../../constants');
 
 /**
  * @typedef {import('@hathor/wallet-lib').SendTransaction} SendTransaction
@@ -135,6 +136,58 @@ async function getAddressInfo(req, res) {
     } else {
       throw error;
     }
+  }
+}
+
+/**
+ * Sign an arbitrary message with one of the wallet's address keys.
+ *
+ * Body params (at least one of `address_index` or `address` is required):
+ *   - message:       string — the payload to sign
+ *   - address_index: int    — derivation index of the address that will sign
+ *   - address:       string — alternative: resolved to index via wallet.getAddressIndex
+ *
+ * Response (success): { success: true, signature, address, index }
+ * Response (failure): { success: false, error }
+ *
+ * The signature is the wallet-lib's `signMessageWithAddress` output — a
+ * Bitcoin-compatible signed-message string (bitcore.Message). Verification on
+ * the consumer side uses the corresponding `verifyMessage` primitive.
+ */
+async function signMessage(req, res) {
+  const validationResult = parametersValidation(req);
+  if (!validationResult.success) {
+    res.status(400).json(validationResult);
+    return;
+  }
+  /**
+   * @type {HathorWallet} wallet - Wallet object
+   */
+  const { wallet } = req;
+  const { message, address_index: explicitIndex, address } = matchedData(req, { locations: ['body'] });
+
+  try {
+    let index = explicitIndex;
+    if (index == null) {
+      if (address == null) {
+        res.send({ success: false, error: 'one of address_index or address is required' });
+        return;
+      }
+      index = await wallet.getAddressIndex(address);
+      if (index == null) {
+        res.send({ success: false, error: 'address does not belong to the wallet' });
+        return;
+      }
+    }
+    const signature = await wallet.signMessageWithAddress(message, index, DEFAULT_PIN);
+    // Always derive the response address from the index actually used to sign.
+    // If the caller passed both `address` and `address_index`, the index wins
+    // (documented in api-docs.js) — we must not echo back an address whose key
+    // didn't produce the signature, otherwise downstream verifyMessage fails.
+    const resolvedAddress = await wallet.getAddressAtIndex(index);
+    res.send({ success: true, signature, address: resolvedAddress, index });
+  } catch (err) {
+    res.send({ success: false, error: err.message });
   }
 }
 
@@ -857,6 +910,7 @@ module.exports = {
   getBalance,
   getAddress,
   getAddressIndex,
+  signMessage,
   getAddresses,
   getAddressInfo,
   getTxHistory,

--- a/src/routes/wallet/wallet.routes.js
+++ b/src/routes/wallet/wallet.routes.js
@@ -12,7 +12,7 @@ const {
   getStatus, getBalance, getAddress, getAddresses, getTxHistory, getTransaction,
   simpleSendTx, decodeTx, sendTx, createToken, mintTokens, meltTokens, utxoFilter,
   utxoConsolidation, createNft, getAddressInfo, stop,
-  getAddressIndex, getTxConfirmationBlocks,
+  getAddressIndex, signMessage, getTxConfirmationBlocks,
   utxosSelectedAsInput,
 } = require('../../controllers/wallet/wallet.controller');
 const {
@@ -73,6 +73,19 @@ walletRouter.get(
   '/address-index',
   query('address').isString(),
   getAddressIndex
+);
+
+/**
+ * POST request to sign an arbitrary message with one of the wallet's address
+ * keys. Either `address_index` or `address` must be provided.
+ * For the docs, see api-docs.js
+ */
+walletRouter.post(
+  '/sign-message',
+  body('message').isString().isLength({ min: 1 }),
+  body('address_index').optional().isInt({ min: 0 }).toInt(),
+  body('address').optional().isString(),
+  signMessage,
 );
 
 /**


### PR DESCRIPTION
### Motivation

`wallet-lib` already exposes `signMessageWithAddress`, but there's no HTTP                                                                                                  
  surface for it. Any HTTP client wanting an address-key signature has to embed                                                                                                 wallet-lib or fork a controller.                                                                                                                                            

Motivating use case: the [x402 payment protocol on Hathor](https://github.com/HathorNetwork/rfcs/pull/109).                                                                 
  The payer broadcasts a payment tx, then signs the server's `requestId` once per                                                                                             
  unique input address as proof of control over every funding source. This                                                                                                    
  endpoint lets a thin client (curl, an AI-agent skill) do that without vendoring                                                                                             
  wallet-lib.

### Acceptance Criteria
-   Adds `POST /wallet/sign-message` — signs an arbitrary message with one of the                                                                                               
  wallet's address keys and returns a bitcore.Message-compatible signature plus                                                                                               
  the resolved `{address, index}`. Verifiable off the wire via                                                                                                                
  `cryptoUtils.verifyMessage`.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /wallet/sign-message to let wallets sign arbitrary messages; supports selecting signer by index or address (index takes precedence) and returns signature, address, and index.

* **Documentation**
  * API docs updated with request/response schema and error cases for missing inputs, invalid index, or address not in wallet.

* **Tests**
  * Integration tests covering successful signing, precedence rules, and validation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->