### PR TITLE
feat(start): accept scanPolicy='single-address' in POST /start

### DIFF
--- a/__tests__/integration/start.test.js
+++ b/__tests__/integration/start.test.js
@@ -1,0 +1,83 @@
+import { precalculationHelpers } from '../../scripts/helpers/wallet-precalculation.helper';
+import { TestUtils } from './utils/test-utils-integration';
+import { initializedWallets } from '../../src/services/wallets.service';
+
+describe('start scanPolicy integration', () => {
+  it('should start a wallet with scanPolicy=single-address and only load address 0', async () => {
+    // Fresh, never-funded precalculated wallet — no on-chain history means
+    // wallet-lib's enableSingleAddressMode check won't downgrade to gap-limit.
+    const walletId = 'startScanPolicySingleAddress';
+    const { words, addresses } = precalculationHelpers.test.getPrecalculatedWallet();
+
+    const response = await TestUtils.request
+      .post('/start')
+      .send({
+        seed: words,
+        'wallet-id': walletId,
+        scanPolicy: 'single-address',
+      });
+    expect(response.status).toEqual(200);
+    expect(response.body.success).toBe(true);
+
+    try {
+      await TestUtils.poolUntilWalletReady(walletId);
+
+      // First address must be loaded and match the precalculated one.
+      const addrResp = await TestUtils.request
+        .get('/wallet/address')
+        .query({ index: 0 })
+        .set({ 'x-wallet-id': walletId });
+      expect(addrResp.body.address).toEqual(addresses[0]);
+
+      // Storage must report single-address policy with no carried-over fields.
+      const wallet = initializedWallets.get(walletId);
+      await expect(wallet.storage.getScanningPolicy()).resolves.toBe('single-address');
+      await expect(wallet.storage.getScanningPolicyData()).resolves.toEqual({
+        policy: 'single-address',
+      });
+      // Only address index 0 is ever generated.
+      await expect(wallet.storage.store.addressCount()).resolves.toBe(1);
+    } finally {
+      await TestUtils.stopWallet(walletId);
+    }
+  });
+
+  it('should ignore gapLimit / policyStartIndex when scanPolicy=single-address', async () => {
+    const walletId = 'startScanPolicySingleAddressIgnoresTunables';
+    const { words, addresses } = precalculationHelpers.test.getPrecalculatedWallet();
+
+    const response = await TestUtils.request
+      .post('/start')
+      .send({
+        seed: words,
+        'wallet-id': walletId,
+        scanPolicy: 'single-address',
+        // These should be silently dropped — single-address has no tunables.
+        gapLimit: 50,
+        policyStartIndex: 7,
+        policyEndIndex: 12,
+      });
+    expect(response.status).toEqual(200);
+    expect(response.body.success).toBe(true);
+
+    try {
+      await TestUtils.poolUntilWalletReady(walletId);
+
+      const addrResp = await TestUtils.request
+        .get('/wallet/address')
+        .query({ index: 0 })
+        .set({ 'x-wallet-id': walletId });
+      expect(addrResp.body.address).toEqual(addresses[0]);
+
+      const wallet = initializedWallets.get(walletId);
+      await expect(wallet.storage.getScanningPolicy()).resolves.toBe('single-address');
+      // Policy data must not contain gapLimit/startIndex/endIndex.
+      await expect(wallet.storage.getScanningPolicyData()).resolves.toEqual({
+        policy: 'single-address',
+      });
+      await expect(wallet.storage.store.addressCount()).resolves.toBe(1);
+    } finally {
+      await TestUtils.stopWallet(walletId);
+    }
+  });
+});

--- a/__tests__/integration/start.test.js
+++ b/__tests__/integration/start.test.js
@@ -1,5 +1,6 @@
 import { precalculationHelpers } from '../../scripts/helpers/wallet-precalculation.helper';
 import { TestUtils } from './utils/test-utils-integration';
+import { WalletHelper } from './utils/wallet-helper';
 import { initializedWallets } from '../../src/services/wallets.service';
 
 describe('start scanPolicy integration', () => {
@@ -87,40 +88,34 @@ describe('start scanPolicy integration', () => {
     // controller relies on wallet-lib's own fallback to gap-limit. This test
     // proves that fallback survives the headless wrapper.
     const walletId = 'startScanPolicySingleAddressDowngrade';
-    const { words, addresses } = precalculationHelpers.test.getPrecalculatedWallet();
 
-    // 1. Start with the default policy (gap-limit) so address index 1 is loaded
-    //    and can receive on-chain funds.
-    const gapLimitStart = await TestUtils.request
-      .post('/start')
-      .send({ seed: words, 'wallet-id': walletId });
-    expect(gapLimitStart.body.success).toBe(true);
-    await TestUtils.poolUntilWalletReady(walletId);
+    // 1. Start with the default policy (gap-limit) via WalletHelper, which also
+    //    brings up the genesis wallet that injectFunds sends from. Address index
+    //    1 is loaded (gap-limit) so it can receive on-chain funds.
+    const wallet = WalletHelper.getPrecalculatedWallet(walletId);
+    await WalletHelper.startMultipleWalletsForTest([wallet]);
 
-    try {
-      // 2. Put a transaction on address index 1 (not the first address).
-      await TestUtils.injectFundsIntoAddress(addresses[1], 100, walletId);
-    } finally {
-      // 3. Stop the wallet — single-address can only be requested at /start.
-      await TestUtils.stopWallet(walletId);
-    }
+    // 2. Put a transaction on address index 1 (not the first address).
+    await wallet.injectFunds(100, 1);
+    // 3. Stop the wallet — single-address can only be requested at /start.
+    await wallet.stop();
 
     // 4. Restart the same seed asking for single-address. The on-chain tx on
     //    address 1 must force the downgrade.
     const singleAddressStart = await TestUtils.request
       .post('/start')
-      .send({ seed: words, 'wallet-id': walletId, scanPolicy: 'single-address' });
+      .send({ seed: wallet.words, 'wallet-id': walletId, scanPolicy: 'single-address' });
     expect(singleAddressStart.body.success).toBe(true);
 
     try {
       await TestUtils.poolUntilWalletReady(walletId);
 
-      const wallet = initializedWallets.get(walletId);
+      const startedWallet = initializedWallets.get(walletId);
       // Policy was silently downgraded to gap-limit, matching the documented
       // behavior in the /start API docs.
-      await expect(wallet.storage.getScanningPolicy()).resolves.toBe('gap-limit');
+      await expect(startedWallet.storage.getScanningPolicy()).resolves.toBe('gap-limit');
       // And it behaves like a gap-limit wallet: more than one address is loaded.
-      await expect(wallet.storage.store.addressCount()).resolves.toBeGreaterThan(1);
+      await expect(startedWallet.storage.store.addressCount()).resolves.toBeGreaterThan(1);
     } finally {
       await TestUtils.stopWallet(walletId);
     }

--- a/__tests__/integration/start.test.js
+++ b/__tests__/integration/start.test.js
@@ -80,4 +80,83 @@ describe('start scanPolicy integration', () => {
       await TestUtils.stopWallet(walletId);
     }
   });
+
+  it('should downgrade to gap-limit when the seed has txs on addresses other than 0', async () => {
+    // wallet-lib refuses single-address mode when the wallet already has
+    // history outside index 0 (HasTxOutsideFirstAddressError), and the headless
+    // controller relies on wallet-lib's own fallback to gap-limit. This test
+    // proves that fallback survives the headless wrapper.
+    const walletId = 'startScanPolicySingleAddressDowngrade';
+    const { words, addresses } = precalculationHelpers.test.getPrecalculatedWallet();
+
+    // 1. Start with the default policy (gap-limit) so address index 1 is loaded
+    //    and can receive on-chain funds.
+    const gapLimitStart = await TestUtils.request
+      .post('/start')
+      .send({ seed: words, 'wallet-id': walletId });
+    expect(gapLimitStart.body.success).toBe(true);
+    await TestUtils.poolUntilWalletReady(walletId);
+
+    try {
+      // 2. Put a transaction on address index 1 (not the first address).
+      await TestUtils.injectFundsIntoAddress(addresses[1], 100, walletId);
+    } finally {
+      // 3. Stop the wallet — single-address can only be requested at /start.
+      await TestUtils.stopWallet(walletId);
+    }
+
+    // 4. Restart the same seed asking for single-address. The on-chain tx on
+    //    address 1 must force the downgrade.
+    const singleAddressStart = await TestUtils.request
+      .post('/start')
+      .send({ seed: words, 'wallet-id': walletId, scanPolicy: 'single-address' });
+    expect(singleAddressStart.body.success).toBe(true);
+
+    try {
+      await TestUtils.poolUntilWalletReady(walletId);
+
+      const wallet = initializedWallets.get(walletId);
+      // Policy was silently downgraded to gap-limit, matching the documented
+      // behavior in the /start API docs.
+      await expect(wallet.storage.getScanningPolicy()).resolves.toBe('gap-limit');
+      // And it behaves like a gap-limit wallet: more than one address is loaded.
+      await expect(wallet.storage.store.addressCount()).resolves.toBeGreaterThan(1);
+    } finally {
+      await TestUtils.stopWallet(walletId);
+    }
+  });
+
+  it('always offers address index 0 as the current address on a single-address wallet', async () => {
+    // The current/next address must never advance past index 0: wallet-lib pins
+    // currentAddressIndex to 0 (setCurrentAddressIndex is a no-op for index > 0),
+    // so even mark_as_used calls keep returning the first address.
+    const walletId = 'startScanPolicySingleAddressCurrent';
+    const { words, addresses } = precalculationHelpers.test.getPrecalculatedWallet();
+
+    const response = await TestUtils.request
+      .post('/start')
+      .send({ seed: words, 'wallet-id': walletId, scanPolicy: 'single-address' });
+    expect(response.body.success).toBe(true);
+
+    try {
+      await TestUtils.poolUntilWalletReady(walletId);
+
+      // Repeated next-address requests (even marking as used) always return 0.
+      const first = await TestUtils.getAddressAt(walletId, undefined, true);
+      const second = await TestUtils.getAddressAt(walletId, undefined, true);
+      expect(first).toEqual(addresses[0]);
+      expect(second).toEqual(addresses[0]);
+
+      // Requesting an explicit index > 0 still derives the address (wallet-lib
+      // derives on demand from the xpub), but it is never loaded/tracked — the
+      // wallet keeps a single loaded address.
+      const derived = await TestUtils.getAddressAt(walletId, 5);
+      expect(derived).toEqual(addresses[5]);
+
+      const wallet = initializedWallets.get(walletId);
+      await expect(wallet.storage.store.addressCount()).resolves.toBe(1);
+    } finally {
+      await TestUtils.stopWallet(walletId);
+    }
+  });
 });

--- a/__tests__/start.test.js
+++ b/__tests__/start.test.js
@@ -249,4 +249,52 @@ describe('start api', () => {
     // We will load 6 addresses, from 5 to 10 (inclusive)
     await expect(wallet.storage.store.addressCount()).resolves.toBe(6);
   });
+  it('should start a wallet with single-address', async () => {
+    const walletHttpInput = {
+      'wallet-id': walletId,
+      seed: WALLET_CONSTANTS.genesis.words,
+      scanPolicy: 'single-address',
+    };
+
+    const response = await TestUtils.request
+      .post('/start')
+      .send(walletHttpInput);
+
+    expect(response.body).toHaveProperty('success', true);
+
+    // Storage is configured during wallet.start() (which awaits before the HTTP
+    // response). Don't waitReady here: the unit-test http mock returns the same
+    // address_history fixture for every address, which makes wallet-lib's
+    // single-address mode self-downgrade to gap-limit when the connection
+    // becomes READY. The actual single-address behavior is covered by the
+    // integration test in __tests__/integration/start.test.js.
+    const wallet = initializedWallets.get(walletId);
+    await expect(wallet.storage.getScanningPolicy()).resolves.toBe('single-address');
+  });
+  it('should ignore gapLimit / policyStartIndex when scanPolicy is single-address', async () => {
+    const walletHttpInput = {
+      'wallet-id': walletId,
+      seed: WALLET_CONSTANTS.genesis.words,
+      scanPolicy: 'single-address',
+      // These should be ignored — single-address has no tunables, same
+      // as how the gap-limit branch ignores policyStartIndex.
+      gapLimit: 50,
+      policyStartIndex: 7,
+      policyEndIndex: 12,
+    };
+
+    const response = await TestUtils.request
+      .post('/start')
+      .send(walletHttpInput);
+
+    expect(response.body).toHaveProperty('success', true);
+
+    // See note in previous test — no waitReady, otherwise the mock-driven
+    // downgrade would mask the policyData we want to inspect.
+    const wallet = initializedWallets.get(walletId);
+    await expect(wallet.storage.getScanningPolicy()).resolves.toBe('single-address');
+    await expect(wallet.storage.getScanningPolicyData()).resolves.toEqual({
+      policy: 'single-address',
+    });
+  });
 });

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -237,7 +237,7 @@ const defaultApiDocs = {
                   scanPolicy: {
                     type: 'string',
                     enum: ['gap-limit', 'index-limit', 'single-address'],
-                    description: 'Address scanning policy to use. \'single-address\' loads only address index 0 and never generates more — matches the wallet-lib v3 default; pass it explicitly to opt out of headless\'s gap-limit override. Note: if the wallet already has transactions on any address other than index 0, single-address mode is automatically downgraded to the default gap-limit policy.',
+                    description: 'Address scanning policy to use. \'single-address\' loads and tracks only address index 0; the wallet never automatically generates further addresses — matches the wallet-lib v3 default; pass it explicitly to opt out of headless\'s gap-limit override. Note: if the wallet already has transactions on any address other than index 0, single-address mode is automatically downgraded to the default gap-limit policy.',
                     default: 'gap-limit',
                   },
                   gapLimit: {

--- a/src/api-docs.js
+++ b/src/api-docs.js
@@ -236,8 +236,8 @@ const defaultApiDocs = {
                   },
                   scanPolicy: {
                     type: 'string',
-                    enum: ['gap-limit', 'index-limit'],
-                    description: 'Address scanning policy to use.',
+                    enum: ['gap-limit', 'index-limit', 'single-address'],
+                    description: 'Address scanning policy to use. \'single-address\' loads only address index 0 and never generates more — matches the wallet-lib v3 default; pass it explicitly to opt out of headless\'s gap-limit override. Note: if the wallet already has transactions on any address other than index 0, single-address mode is automatically downgraded to the default gap-limit policy.',
                     default: 'gap-limit',
                   },
                   gapLimit: {

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -158,6 +158,13 @@ async function start(req, res) {
           gapLimit: parseInt(req.body.gapLimit, 10) || GAP_LIMIT,
         };
         break;
+      case 'single-address':
+        // Match wallet-lib v3's own default: load only address index 0, never
+        // generate more. No tunables — the policy is fully described by its
+        // discriminator. Any body fields like `gapLimit` / `policyStartIndex`
+        // are ignored, same way `gap-limit` ignores `policyStartIndex`.
+        scanPolicyData = { policy };
+        break;
       default:
         // address scanning policy requested is not supported
         res.send({


### PR DESCRIPTION
### Motivation

The new wallet lib has the default load policy as single-address (loads only address 0). We decided that the default of the headless wallet will continue being multi address but it's important to allow users to load single address, if they want.

### Acceptance Criteria
- Accept scan policy 'single-address' in the /start POST API


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `single-address` scanPolicy mode for wallet start, loading and managing only a single address and ignoring other scan-related inputs.

* **Documentation**
  * Updated API docs to include `single-address` and describe its behavior and automatic downgrade when transactions exist on other addresses.

* **Tests**
  * Added integration tests validating `single-address` behavior, input ignoring, downgrade behavior, and address advancement rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->