### PR TITLE
chore: bump to v0.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.41.0-rc.1",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-wallet-headless",
-      "version": "0.41.0-rc.1",
+      "version": "0.41.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-headless",
-  "version": "0.41.0-rc.1",
+  "version": "0.41.0",
   "description": "Hathor Wallet Headless, i.e., without graphical user interface",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Acceptance Criteria
- Bump package to v0.41.0

### What's included

| PR | Type | Title |
|---|---|---|
| #605 | feat | add `POST /wallet/sign-message` endpoint |
| #607 | feat | accept `scanPolicy='single-address'` in `POST /start` |
| #611 | feat | route multisig wallets to manual stream sync |

> Note: #611 bumps `@hathor/wallet-lib` `3.1.1` → `4.0.0`. The only breaking change in wallet-lib `v4.0.0` (the `WalletRequestError.cause` retype) is not used in this repo, so there is no change to the headless HTTP API contract.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
